### PR TITLE
Debounce window resize handler

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -434,7 +434,11 @@ function syncHUDForMode(modeId) {
   }
 }
 
-window.addEventListener('resize', () => resize(canvas));
+let resizeTimer;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => resize(canvas), 150);
+});
 
 // Restore active mode then load per-mode saved state
 loadActiveMode();


### PR DESCRIPTION
Resolves #22. Wraps the canvas resize handler in a 150ms setTimeout to prevent layout thrashing and canvas flickering during continuous window resizes or mobile orientation changes.