### PR TITLE
fix: pass animation ctx to all call sites — game hangs after selection (#28)

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -334,8 +334,8 @@ export async function animateBlackPearlCreation(ctx, bpResults) {
 
   applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
   const mode = getActiveGameMode();
-  const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && bombQueued, { starflowers: 0, blackpearls: queuedBlackpearls }, mode.isPuzzle);
-  if (mode.hasBombs && bombQueued && filled.length > 0) ctx.setBombQueued(false);
+  const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, { starflowers: 0, blackpearls: queuedBlackpearls }, mode.isPuzzle);
+  if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
 }
 
 export async function animateGrandPoobahCreation(ctx, gpResults) {
@@ -435,17 +435,17 @@ export async function animateGrandPoobahCreation(ctx, gpResults) {
 
   applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
   const mode = getActiveGameMode();
-  const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && bombQueued, { starflowers: 0, blackpearls: 0, grandpoobahs: queuedGrandPoobahs }, mode.isPuzzle);
-  if (mode.hasBombs && bombQueued && filled.length > 0) ctx.setBombQueued(false);
+  const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, { starflowers: 0, blackpearls: 0, grandpoobahs: queuedGrandPoobahs }, mode.isPuzzle);
+  if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
 
-  handleGameWin();
+  ctx.handleGameWin();
 }
 
 export async function handleOverAchiever(ctx) {
   ctx.setState('gameover');
-  const combinedId = getCombinedModeId();
-  clearGameState(combinedId);
-  addHighScore(combinedId, getScore(), 'over-achiever');
+  const combinedId = ctx.getCombinedModeId();
+  ctx.clearGameState(combinedId);
+  ctx.addHighScore(combinedId, getScore(), 'over-achiever');
 
   document.getElementById('go-oa-score').textContent = getScore().toLocaleString();
   document.getElementById('go-oa-combo').textContent = `x${getComboCount()}`;
@@ -499,9 +499,9 @@ export async function handleOverAchiever(ctx) {
 
 export async function handleGameOver(ctx, isSessionEnd = false) {
   ctx.setState('gameover');
-  const combinedId = getCombinedModeId();
-  clearGameState(combinedId);
-  addHighScore(combinedId, getScore());
+  const combinedId = ctx.getCombinedModeId();
+  ctx.clearGameState(combinedId);
+  ctx.addHighScore(combinedId, getScore());
   console.log('Game/Session Over. High score saved.');
 
   // 1. Show Game Over Modal (only if not a peaceful chill session end)
@@ -713,8 +713,8 @@ export async function animateStarflowerCreation(ctx, sfResults) {
   applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
   {
     const mode = getActiveGameMode();
-    const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && bombQueued, { starflowers: queuedStarflowers, blackpearls: 0 }, mode.isPuzzle);
-    if (mode.hasBombs && bombQueued && filled.length > 0) ctx.setBombQueued(false);
+    const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, { starflowers: queuedStarflowers, blackpearls: 0 }, mode.isPuzzle);
+    if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
   }
 }
 
@@ -987,8 +987,8 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
   applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
   {
     const mode = getActiveGameMode();
-    const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && bombQueued, undefined, mode.isPuzzle);
-    if (mode.hasBombs && bombQueued && filled.length > 0) ctx.setBombQueued(false);
+    const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, undefined, mode.isPuzzle);
+    if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
   }
   requestRedraw();
 

--- a/js/main.js
+++ b/js/main.js
@@ -82,7 +82,11 @@ export const getAnimationContext = () => ({
   get moveCount() { return moveCount; },
   get bombQueued() { return bombQueued; },
   setBombQueued(q) { bombQueued = q; },
-  resetGame: () => resetGame()
+  resetGame: () => resetGame(),
+  handleGameWin: () => handleGameWin(),
+  getCombinedModeId,
+  clearGameState,
+  addHighScore,
 });
 // ─── Game state ─────────────────────────────────────────────────
 let grid;
@@ -353,7 +357,7 @@ document.getElementById('btn-confirm-end').addEventListener('click', (e) => {
   requestRedraw();
   
   // End session logic: trigger explosion sequence
-  handleGameOver(true);
+  handleGameOver(getAnimationContext(), true);
 });
 
 function showHighScores() {
@@ -740,6 +744,7 @@ async function animateRotation(clockwise) {
   if (state !== 'selected') return;
   state = 'rotating';
   const gen = boardGeneration;
+  const ctx = getAnimationContext();
 
   const { originX, originY } = getOrigin();
 
@@ -752,11 +757,11 @@ async function animateRotation(clockwise) {
   for (let step = 0; step < maxSteps; step++) {
     // 1. Animate one step
     if (flowerCenter) {
-      await animateRingRotation(clockwise, originX, originY);
+      await animateRingRotation(ctx, clockwise, originX, originY);
     } else if (pearlCenter) {
-      await animateYRotation(clockwise, originX, originY);
+      await animateYRotation(ctx, clockwise, originX, originY);
     } else {
-      await animateClusterRotation(clockwise, originX, originY);
+      await animateClusterRotation(ctx, clockwise, originX, originY);
     }
     if (boardGeneration !== gen) return; // board was replaced (e.g. restart)
 
@@ -791,6 +796,7 @@ async function postRotationCheck(gen) {
   // Guard: callers must pass gen so stale async chains bail correctly.
   if (gen === undefined) gen = boardGeneration;
   moveCount++;
+  const ctx = getAnimationContext();
 
   const mode = getActiveGameMode();
 
@@ -839,7 +845,7 @@ async function postRotationCheck(gen) {
     // Check for Grand Poobah Ring (Over-Achiever) before anything else
     const gpRing = detectGrandPoobahRing(grid);
     if (gpRing.length > 0) {
-      await handleOverAchiever();
+      await handleOverAchiever(ctx);
       return;
     }
 
@@ -849,7 +855,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      await animateGrandPoobahCreation(gpResults);
+      await animateGrandPoobahCreation(ctx, gpResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
       continue;
@@ -861,7 +867,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      await animateBlackPearlCreation(bpResults);
+      await animateBlackPearlCreation(ctx, bpResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
       continue;
@@ -873,7 +879,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      await animateStarflowerCreation(sfResults);
+      await animateStarflowerCreation(ctx, sfResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
       continue;
@@ -885,7 +891,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      await runCascade(matches, gen);
+      await runCascade(ctx, matches, gen);
       if (boardGeneration !== gen) return;
       boardStable = false;
       continue;
@@ -927,7 +933,7 @@ async function postRotationCheck(gen) {
       }
     }
     if (exploded) {
-       handleGameOver(false);
+       handleGameOver(ctx, false);
        return;
     }
   }
@@ -981,7 +987,7 @@ async function startCascade() {
     return;
   }
 
-  await runCascade(matches);
+  await runCascade(getAnimationContext(), matches);
 
   selectedCluster = null;
   state = 'idle';


### PR DESCRIPTION
## Summary

- PR #25 extracted animation functions to `animations.js` with `ctx` as first param, but **all call sites in `main.js` were never updated** to pass it
- Every rotation attempted to call `animateClusterRotation(clockwise, originX, originY)` — `ctx` received the boolean `clockwise`, `ctx.selectedCluster` returned `undefined`, `undefined.map()` threw a TypeError, and `state` was left stuck at `'rotating'` permanently → game hangs
- Also fixes 5 bare undefined references in `animations.js` (`bombQueued`, `handleGameWin`, `getCombinedModeId`, `clearGameState`, `addHighScore`) that were `ReferenceError`s at runtime

## Changes

**`js/main.js`**
- Added `handleGameWin`, `getCombinedModeId`, `clearGameState`, `addHighScore` to `getAnimationContext()`
- Added `const ctx = getAnimationContext()` in `animateRotation` and `postRotationCheck`
- Fixed all 11 call sites to pass `ctx` as first argument

**`js/animations.js`**
- Replaced `bombQueued` → `ctx.bombQueued` (4 locations)
- Replaced `handleGameWin()` → `ctx.handleGameWin()`
- Replaced `getCombinedModeId()`, `clearGameState()`, `addHighScore()` → `ctx.xxx` (2 locations each)

## Test plan

- [ ] Tap a hex cell — cluster highlights and game does not hang
- [ ] Rotate a cluster — animation plays, state returns to `idle`/`selected`
- [ ] Trigger a cascade — board resolves correctly
- [ ] Trigger a black pearl / grand poobah creation — animation + refill works
- [ ] Bomb explodes at 0 — game over modal appears
- [ ] "End Session" button triggers explosion sequence correctly

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)