### PR TITLE
Add postMessage localStorage shim for sandboxed launcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,48 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>
+  // Sandboxed-iframe localStorage shim. When loaded inside the launcher's
+  // sandboxed iframe (no allow-same-origin), parent's localStorage is
+  // unreachable directly — proxy via postMessage to the launcher's
+  // gameStorageProxy IIFE. Standalone (window.parent === window): no-op.
+  (function () {
+    if (window.parent === window) return;
+    var cache = Object.create(null);
+    var pending = Object.create(null);
+    var nextId = 0;
+    function send(op, payload) {
+      var requestId = String(++nextId);
+      var p = new Promise(function (resolve) { pending[requestId] = resolve; });
+      window.parent.postMessage(
+        Object.assign({ type: 'ls-proxy-request', requestId: requestId, op: op }, payload || {}),
+        '*'
+      );
+      return p;
+    }
+    window.addEventListener('message', function (e) {
+      if (e.source !== window.parent) return;
+      var d = e.data;
+      if (!d || d.type !== 'ls-proxy-response') return;
+      var resolver = pending[d.requestId];
+      if (resolver) { delete pending[d.requestId]; resolver(d); }
+    });
+    var shim = {
+      getItem: function (k) { return Object.prototype.hasOwnProperty.call(cache, k) ? cache[k] : null; },
+      setItem: function (k, v) { var s = String(v); cache[k] = s; send('setItem', { key: k, value: s }); },
+      removeItem: function (k) { delete cache[k]; send('removeItem', { key: k }); },
+      clear: function () { cache = Object.create(null); send('clear'); },
+      key: function (i) { return Object.keys(cache)[i] || null; },
+      get length() { return Object.keys(cache).length; }
+    };
+    Object.defineProperty(window, 'localStorage', { value: shim, configurable: true });
+    window.__storageReady = send('dump').then(function (reply) {
+      if (reply && reply.ok && reply.data) {
+        Object.keys(reply.data).forEach(function (k) { cache[k] = reply.data[k]; });
+      }
+    });
+  })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/js/main.js
+++ b/js/main.js
@@ -68,6 +68,12 @@ import {
   onPuzzleMove, onStarflowerCreated,
 } from './puzzle-mode.js';
 
+// In sandboxed-iframe context (launcher), wait for postMessage-backed
+// localStorage to hydrate before any save data is read.
+if (typeof window !== 'undefined' && window.__storageReady) {
+  await window.__storageReady;
+}
+
 
 // ─── Animation Context ───
 export const getAnimationContext = () => ({


### PR DESCRIPTION
## Summary

Adds a `postMessage`-based `localStorage` shim so this game keeps working when launched from the sandboxed iframe at https://paulgibeault.github.io/.

- Replaces `window.localStorage` with a sync-cache proxy that talks the launcher's `ls-proxy-request` protocol via `postMessage` (see paulgibeault/paulgibeault.github.io#5).
- Cache hydrates from a single `dump` request on load. `getItem` reads the cache synchronously; `setItem`/`removeItem` update cache and fire async write-throughs to the parent.
- Standalone mode (`window.parent === window`) is a no-op — direct `localStorage` is left untouched, so opening this page outside the launcher works exactly as before.
- `js/main.js` gates module init on `window.__storageReady` (top-level `await`) so `loadSettings()` / `loadGameState()` / `getPlayerName()` see the hydrated cache before the first frame.

## Why

Without this, every `js/storage.js` call (`hecknsic_state_*`, `hecknsic_settings`, `hecknsic_puzzle_*`, `hecknsic_highscores_*`, `hecknsic_player_name`) throws `SecurityError` inside the launcher iframe.

## Test plan

- [ ] Serve `paulgibeault.github.io` locally with the matching launcher PR applied; click "HecknSic".
- [ ] Play a few rounds. Set a player name. Quit. Re-enter — high scores, settings, and saved game state restore.
- [ ] Open `https://paulgibeault.github.io/hecknsic/` standalone — direct localStorage still works (no shim engaged).

Depends on paulgibeault/paulgibeault.github.io#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
