### PR TITLE
Arcade review fixes: SW SDK caching + orphaned .ls.* migration + fontScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Hecknsic is a captivating puzzle game designed for modern web platforms, inspire
   - **Bomb**: Explode a large area.
 - **Combo Chains**: Create cascading matches for exponential score multipliers.
 - **Responsive Design**: Playable on desktop and mobile devices.
+- **Dark Theme Only**: The board is styled dark-only and does not respond to
+  a host platform's light theme setting.
 
 ## How to Play
 

--- a/css/style.css
+++ b/css/style.css
@@ -107,7 +107,7 @@ html, body {
   background: rgba(255, 255, 255, 0.07);
   border: 1px solid rgba(255, 255, 255, 0.12);
   color: rgba(255, 255, 255, 0.35);
-  font-size: 10px;
+  font-size: calc(10px * var(--font-scale, 1));
   display: flex;
   align-items: center;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -12,19 +12,26 @@
   <link rel="apple-touch-icon" href="img/icon-192.png">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/overlays.css">
-  <script src="https://paulgibeault.github.io/arcade-sdk.js"></script>
+  <script src="/arcade-sdk.js"></script>
   <script>
     Arcade.init({ gameId: 'hecknsic' });
 
     // One-shot migration of pre-Arcade keys into the namespaced layout.
     // Scores and player name are dropped on purpose — fresh leaderboard
     // under the new SDK; player name re-typed on first save.
-    Arcade.state.migrate('v1', function () {
+    //
+    // rawPrefix locates the legacy keys to read: '' for keys written directly
+    // by this page (v1), or the launcher's ls-proxy namespace for keys that
+    // were shimmed through postMessage while framed in the sandboxed iframe
+    // (v2) — see commit 47faee4, since removed. Those `.ls.` keys were never
+    // read by v1 and are otherwise dead weight forever.
+    function migrateLegacyKeys(rawPrefix) {
       function take(key) {
+        var full = rawPrefix + key;
         var raw;
-        try { raw = localStorage.getItem(key); } catch (e) { return null; }
+        try { raw = localStorage.getItem(full); } catch (e) { return null; }
         if (raw === null) return null;
-        try { localStorage.removeItem(key); } catch (e) {}
+        try { localStorage.removeItem(full); } catch (e) {}
         return raw;
       }
       function takeJSON(key) {
@@ -54,7 +61,7 @@
       try {
         for (var i = 0; i < localStorage.length; i++) {
           var k = localStorage.key(i);
-          if (k) keys.push(k);
+          if (k && k.indexOf(rawPrefix) === 0) keys.push(k.substring(rawPrefix.length));
         }
       } catch (e) {}
       keys.forEach(function (k) {
@@ -70,7 +77,10 @@
           take(k); // dropped, not migrated
         }
       });
-    });
+    }
+
+    Arcade.state.migrate('v1', function () { migrateLegacyKeys(''); });
+    Arcade.state.migrate('v2', function () { migrateLegacyKeys('arcade.v1.hecknsic.ls.'); });
   </script>
 </head>
 <body>

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,7 @@ import {
   spawnColorNukeParticles, spawnExplosionParticles,
   spawnRingShockwave, flashScreenOverlay,
   requestRedraw, clearDirty, getIsDirty, hasActiveRendererAnimations,
-  setActiveGridSize,
+  setActiveGridSize, setFontScale,
 } from './renderer.js';
 import {
   loadActiveMode, getActiveGameMode, getActiveMatchMode,
@@ -99,6 +99,7 @@ let selectedCluster = null;
 let flowerCenter = null;     // {col,row} if a starflower ring is selected
 let pearlCenter = null;      // {col,row} if a black pearl Y-shape is selected
 let lastTime = 0;
+let rafId = null;
 let moveCount = 0;           // total player moves (for bomb spawn timing)
 let bombQueued = false;
 let boardGeneration = 0;  // incremented on grid replacement; stale async chains bail out
@@ -125,8 +126,15 @@ initInput(canvas);
 // isPaused flag already short-circuits gameLoop. Reset lastTime on resume so
 // dt doesn't jump after a long suspension.
 if (typeof window !== 'undefined' && window.Arcade) {
-  Arcade.onSuspend(() => { isPaused = true; });
-  Arcade.onResume(() => { isPaused = false; lastTime = performance.now(); });
+  Arcade.onSuspend(() => {
+    isPaused = true;
+    if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+  });
+  Arcade.onResume(() => {
+    isPaused = false;
+    lastTime = performance.now();
+    rafId = requestAnimationFrame(gameLoop);
+  });
 
   // After the launcher imports a save, every persisted key the game reads at
   // boot has just changed. Re-bootstrap from a clean slate rather than trying
@@ -205,12 +213,21 @@ toggleLeft.addEventListener('click',  (e) => { e.stopPropagation(); Arcade.globa
 toggleRight.addEventListener('click', (e) => { e.stopPropagation(); Arcade.global.set('handedness', 'right'); });
 
 // Reduced motion — short-circuit CSS animations/transitions globally. Canvas
-// tweens are not affected here; respecting them is a separate follow-up.
+// tweens read Arcade.settings.reducedMotion() themselves (js/tween.js).
 function applyReducedMotion() {
   document.body.classList.toggle('reduced-motion', Arcade.settings.reducedMotion());
 }
 applyReducedMotion();
 Arcade.onSettingsChange(applyReducedMotion);
+
+// Canvas text (score popups, bomb timers, combo labels) doesn't scale with the
+// CSS --font-scale variable — cache it here and redraw on change.
+function applyFontScale() {
+  setFontScale(Arcade.settings.fontScale());
+  requestRedraw();
+}
+applyFontScale();
+Arcade.onSettingsChange(applyFontScale);
 
 
 // Help Modal bindings
@@ -577,13 +594,13 @@ if (savedState) {
   state = 'idle';
 }
 
-requestAnimationFrame(gameLoop);
+rafId = requestAnimationFrame(gameLoop);
 
 // ─── Game loop ──────────────────────────────────────────────────
 
 function gameLoop(timestamp) {
   if (isPaused) {
-    requestAnimationFrame(gameLoop);
+    rafId = requestAnimationFrame(gameLoop);
     return;
   }
 
@@ -603,7 +620,7 @@ function gameLoop(timestamp) {
     // drawGameOver(); // Handled by DOM overlay now
     
     updateGameHUD();
-    requestAnimationFrame(gameLoop);
+    rafId = requestAnimationFrame(gameLoop);
     return;
   }
 
@@ -649,7 +666,7 @@ function gameLoop(timestamp) {
   updateControlsVisibility();
   updateGameHUD();
 
-  requestAnimationFrame(gameLoop);
+  rafId = requestAnimationFrame(gameLoop);
 }
 
 /**
@@ -1025,7 +1042,7 @@ function resetGame() {
   // Ensure we are unpaused and running
   isPaused = false;
   lastTime = performance.now();
-  requestAnimationFrame(gameLoop); // Might already be running, but safe to ensure
+  rafId = requestAnimationFrame(gameLoop); // Might already be running, but safe to ensure
 }
 
 function saveGame() {

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -26,6 +26,11 @@ export function requestRedraw() { isDirty = true; }
 export function clearDirty() { isDirty = false; }
 export function getIsDirty() { return isDirty; }
 
+let fontScale = 1;  // Arcade.settings.fontScale(), cached — applied to all ctx.font sizes
+export function setFontScale(scale) {
+  if (typeof scale === 'number' && isFinite(scale) && scale > 0) fontScale = scale;
+}
+
 
 export function hasActiveRendererAnimations() {
   return creationParticles.length > 0 ||
@@ -846,7 +851,7 @@ function drawSpecialIndicator(cx, cy, radius, type, alpha = 1, bombTimer, colorI
       // Timer number (perfectly centered on the tile)
       if (bombTimer !== undefined) {
         ctx.fillStyle = isLow ? '#FF4040' : colorData.light;
-        ctx.font = `bold ${radius * 1.4}px "Segoe UI", system-ui, sans-serif`;
+        ctx.font = `bold ${radius * 1.4 * fontScale}px "Segoe UI", system-ui, sans-serif`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         
@@ -1067,7 +1072,7 @@ function updateAndDrawScorePopups() {
 
     ctx.save();
     ctx.globalAlpha  = fadeA * 0.92;
-    ctx.font         = `bold ${p.fontSize * popIn}px "Segoe UI", system-ui, sans-serif`;
+    ctx.font         = `bold ${p.fontSize * popIn * fontScale}px "Segoe UI", system-ui, sans-serif`;
     ctx.textAlign    = 'center';
     ctx.textBaseline = 'middle';
     ctx.shadowColor  = p.color;
@@ -1162,13 +1167,13 @@ function drawComboOverlay() {
   ctx.shadowColor = color;
   ctx.shadowBlur  = glow;
   ctx.fillStyle   = color;
-  ctx.font = `bold ${labelFontPx}px "Segoe UI", system-ui, sans-serif`;
+  ctx.font = `bold ${labelFontPx * fontScale}px "Segoe UI", system-ui, sans-serif`;
   ctx.fillText(label, 0, -countFontPx * 0.6);
 
   // Count
   ctx.shadowBlur  = glow * 0.5;
   ctx.fillStyle   = '#FFFFFF';
-  ctx.font = `bold ${countFontPx}px "Segoe UI", system-ui, sans-serif`;
+  ctx.font = `bold ${countFontPx * fontScale}px "Segoe UI", system-ui, sans-serif`;
   ctx.fillText(`x${comboDispCount}`, 0, labelFontPx * 0.45);
 
   ctx.restore();

--- a/js/storage.js
+++ b/js/storage.js
@@ -10,8 +10,6 @@
  */
 
 const DEFAULT_SETTINGS = {
-  theme: 'dark',
-  soundVolume: 0.5,
   keyBindings: {
     rotateCW: 'q',
     rotateCCW: 'e',

--- a/js/tween.js
+++ b/js/tween.js
@@ -12,7 +12,8 @@ const active = [];
 export function tween(durationMs, onUpdate, easing = easeOutCubic) {
   let resolve;
   const promise = new Promise(r => { resolve = r; });
-  const entry = { start: -1, duration: durationMs, onUpdate, easing, resolve, cancelled: false };
+  const reducedMotion = typeof Arcade !== 'undefined' && Arcade.settings.reducedMotion();
+  const entry = { start: -1, duration: reducedMotion ? 0 : durationMs, onUpdate, easing, resolve, cancelled: false };
   active.push(entry);
   return {
     promise,
@@ -27,7 +28,7 @@ export function updateTweens(now) {
     if (t.cancelled) { active.splice(i, 1); t.resolve(); continue; }
     if (t.start < 0) t.start = now;
     const elapsed = now - t.start;
-    const raw = Math.min(elapsed / t.duration, 1);
+    const raw = t.duration > 0 ? Math.min(elapsed / t.duration, 1) : 1;
     const progress = t.easing(raw);
     t.onUpdate(progress);
     if (raw >= 1) {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.3.0';
+const APP_VERSION = '1.3.1';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets
@@ -57,6 +57,11 @@ self.addEventListener('fetch', (event) => {
 
   // Cache-first for all GET requests — serves static assets offline.
   if (event.request.method !== 'GET') return;
+
+  // Only handle requests within this game's own scope — otherwise launcher
+  // assets like /arcade-sdk.js get cached under our origin-wide fetch handler
+  // and a stale SDK is served indefinitely.
+  if (!event.request.url.startsWith(self.registration.scope)) return;
 
   event.respondWith(
     caches.match(event.request).then((cached) => {


### PR DESCRIPTION
Addresses #38.

## Fixed
- Service worker cached `/arcade-sdk.js` (and everything) — scoped the fetch handler to the game's own SW scope; bumped `APP_VERSION` to purge poisoned caches.
- Shim-era `arcade.v1.hecknsic.ls.*` data orphaned by the v1 migration — added an `Arcade.state.migrate('v2', …)` that re-runs the mapping and deletes the originals. This unblocks retiring the launcher's ls-proxy path.
- rAF loop wasn't cancelled on suspend (kept re-requesting every frame) — now cancelled/rescheduled around `onSuspend`/`onResume`.
- Canvas text (score popups, bomb timers, handedness pill) ignored `fontScale` — now scaled and redrawn on `onSettingsChange`.
- Cleanup: gated canvas tweens on `reducedMotion`, switched the SDK script tag to root-relative, dropped vestigial unread settings defaults, documented the dark-only theme.

## Not in this PR
- Replacing the editor's status-fade with `Arcade.ui.toast` and adopting `Arcade.stats` — both are UX/product decisions (toast only supports 4 fixed kinds vs. arbitrary hex; stats need a "what counts as a win per mode" call), left for a follow-up.

66/66 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)