### PR TITLE
Arcade review follow-ups: ui.toast editor status, Arcade.stats, device-local daily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ node_modules/
 .idea/
 *.log
 .go.pid
-.arcade-stage/

--- a/index.html
+++ b/index.html
@@ -359,8 +359,6 @@
         <button id="btn-play-from-editor" class="start-btn" style="margin:0;flex:1;background:#8040c0;padding:10px;">▶ Play</button>
       </div>
 
-      <div id="editor-status" class="copy-confirm" style="margin-top:6px; text-align:center; opacity:0;"></div>
-
       <div id="share-code-output" class="share-code-box hidden" title="Tap to copy"></div>
 
       <button id="btn-close-puzzle-editor" class="start-btn" style="background:#222; margin-top:12px;">Close</button>

--- a/js/animations.js
+++ b/js/animations.js
@@ -18,7 +18,7 @@ import {
   detectStarflowersAtCleared, detectBlackPearls, detectMultiplierClusters
 } from './specials.js';
 import { onStarflowerCreated } from './puzzle-mode.js';
-import { getPlayerName } from './storage.js';
+import { getPlayerName, recordGameEnd } from './storage.js';
 
 function prepopulateNameInputs() {
   const name = getPlayerName();
@@ -511,6 +511,7 @@ export async function handleGameOver(ctx, isSessionEnd = false) {
   ctx.setState('gameover');
   const combinedId = ctx.getCombinedModeId();
   ctx.clearGameState(combinedId);
+  recordGameEnd(getMaxCombo());
   // Score is committed when the user confirms their name in modal-gameover
   // (or already committed by btn-confirm-end before this runs, for chill).
 

--- a/js/daily-puzzle.js
+++ b/js/daily-puzzle.js
@@ -34,8 +34,13 @@ function hashString(str) {
 
 export function getDailyDateString(offsetDays = 0) {
   const d = new Date();
-  d.setUTCDate(d.getUTCDate() + offsetDays);
-  return d.toISOString().slice(0, 10); // "YYYY-MM-DD"
+  d.setDate(d.getDate() + offsetDays);
+  // The platform rule (Arcade.daily): dailies roll at the DEVICE-LOCAL
+  // midnight, never UTC. Fall back to the same local-date format when the
+  // SDK isn't loaded (node tests, standalone without the script tag).
+  if (typeof Arcade !== 'undefined' && Arcade.daily) return Arcade.daily.dateStr(d);
+  const p = (n) => (n < 10 ? '0' : '') + n;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
 export function getDailyPuzzleId(dateStr) {

--- a/js/puzzle-editor.js
+++ b/js/puzzle-editor.js
@@ -88,7 +88,7 @@ export function initPuzzleEditorUI() {
     if (!input) return;
     const puzzle = decodePuzzleShareCode(input.value.trim());
     if (!puzzle) {
-      showEditorStatus('❌ Invalid code', '#ff6060');
+      showEditorStatus('❌ Invalid code', 'error');
       return;
     }
     document.getElementById('modal-puzzle-editor').classList.add('hidden');
@@ -102,13 +102,13 @@ export function initPuzzleEditorUI() {
     const board = encodePuzzleBoard(grid, GRID_COLS, GRID_ROWS);
     const ta = document.getElementById('editor-board-string');
     if (ta) ta.value = board;
-    showEditorStatus('✅ Board captured', '#60d060');
+    showEditorStatus('✅ Board captured', 'success');
   });
 
   // Generate share code button
   document.getElementById('btn-generate-code')?.addEventListener('click', () => {
     const board = document.getElementById('editor-board-string')?.value?.trim();
-    if (!board) { showEditorStatus('❌ Capture a board first', '#ff6060'); return; }
+    if (!board) { showEditorStatus('❌ Capture a board first', 'error'); return; }
 
     const name      = document.getElementById('editor-name')?.value || 'Custom Puzzle';
     const desc      = document.getElementById('editor-desc')?.value || '';
@@ -129,17 +129,17 @@ export function initPuzzleEditorUI() {
       codeBox.textContent = code;
       codeBox.onclick = () => {
         navigator.clipboard?.writeText(code).then(() => {
-          showEditorStatus('📋 Copied!', '#b070f0');
+          showEditorStatus('📋 Copied!', 'success');
         });
       };
     }
-    showEditorStatus('✅ Code ready — tap to copy', '#60d060');
+    showEditorStatus('✅ Code ready — tap to copy', 'success');
   });
 
   // Play from editor button
   document.getElementById('btn-play-from-editor')?.addEventListener('click', () => {
     const board     = document.getElementById('editor-board-string')?.value?.trim();
-    if (!board) { showEditorStatus('❌ Capture a board first', '#ff6060'); return; }
+    if (!board) { showEditorStatus('❌ Capture a board first', 'error'); return; }
 
     const name      = document.getElementById('editor-name')?.value || 'Custom Puzzle';
     const cols      = parseInt(document.getElementById('editor-cols')?.value) || GRID_COLS;
@@ -213,13 +213,11 @@ function updateGoalParamLabel(goalType) {
   }
 }
 
-function showEditorStatus(msg, color = '#d0d0d8') {
-  const el = document.getElementById('editor-status');
-  if (!el) return;
-  el.textContent = msg;
-  el.style.color = color;
-  el.style.opacity = '1';
-  setTimeout(() => { el.style.opacity = '0'; }, 2500);
+// Editor status rides the platform toast (launcher-rendered when framed,
+// SDK fallback standalone). The old inline hex colors collapse onto the
+// SDK's kinds: red → error, green → success, everything else → info.
+function showEditorStatus(msg, kind = 'info') {
+  Arcade.ui.toast(msg, { kind });
 }
 
 export function showPuzzleEditor() {

--- a/js/puzzle-mode.js
+++ b/js/puzzle-mode.js
@@ -26,6 +26,7 @@ import {
   getPuzzleProgress,
   savePuzzleProgress,
   isSectorUnlocked,
+  recordPuzzleSolved,
 } from './storage.js';
 import { getTodaysPuzzle, getDailyDateString, getDailyProgress } from './daily-puzzle.js';
 import { showPuzzleEditor, registerEditorCallbacks, initPuzzleEditorUI } from './puzzle-editor.js';
@@ -108,6 +109,7 @@ export function onPuzzleMove(grid, score, chainLevel) {
     puzzleDone = true;
     const stars = computeStars(activePuzzle, movesUsed, maxChain);
     savePuzzleProgress(activePuzzle.id, { stars, movesUsed, score: stats.score ?? 0 });
+    recordPuzzleSolved(!!activePuzzle.isDaily);
     setTimeout(() => showPuzzleResult(stars), 600);
     return;
   }

--- a/js/storage.js
+++ b/js/storage.js
@@ -116,6 +116,27 @@ export function getHighScores(modeId) {
   return Arcade.scores.list(modeId, { limit: 10 });
 }
 
+// ─── Lifetime stats (Arcade.stats, category 'lifetime') ─────────
+// Read by the launcher's records surfaces; nothing in-game renders these yet.
+// A "game" is an arcade/chill run that ended (bomb or session end); a puzzle
+// or daily only counts when actually solved — there is no lose-credit.
+
+export function recordGameEnd(maxCombo) {
+  Arcade.stats.update('lifetime', (s) => ({
+    ...s,
+    gamesPlayed: (s.gamesPlayed || 0) + 1,
+    bestCombo:   Math.max(s.bestCombo || 0, maxCombo || 0),
+  }));
+}
+
+export function recordPuzzleSolved(isDaily) {
+  Arcade.stats.update('lifetime', (s) => ({
+    ...s,
+    puzzlesSolved: (s.puzzlesSolved || 0) + 1,
+    dailiesSolved: (s.dailiesSolved || 0) + (isDaily ? 1 : 0),
+  }));
+}
+
 // ─── Player name (cross-game, lives at arcade.v1.global.playerName) ──
 
 export function getPlayerName() {


### PR DESCRIPTION
Closes #40 (both deferred items decided), plus the daily-seed contract fix.

## 1. Editor status → `Arcade.ui.toast`
`showEditorStatus()` now calls `Arcade.ui.toast` — launcher-rendered chrome when framed (PR paulgibeault.github.io#67), SDK fallback standalone. **Product call:** the simplified kind styling is accepted; the inline hex colors map red→`error`, green/purple→`success`, default→`info`, and the existing emoji prefixes (❌✅📋) keep the specific meaning. Dead `#editor-status` div removed.

## 2. `Arcade.stats` adoption (category `lifetime`)
**Product call on win semantics:**
- `gamesPlayed`+1 and `bestCombo`=max when an arcade/chill run **ends** (`handleGameOver` — bomb and session-end paths)
- `puzzlesSolved`+1 (and `dailiesSolved`+1 for dailies) only on an actual solve — no lose-credit
- nothing in-game renders these yet; they're for the launcher's records surfaces (launcher #12)

## 3. Daily seeds from the device-local date
`getDailyDateString()` now uses `Arcade.daily.dateStr()` (platform rule from launcher #37: dailies roll at the player's midnight, never UTC), with an identical local-date fallback for node tests/standalone. The weekday→goal derivation from a given date string stays UTC-noon-based — deterministic per date string and timezone-safe. One-time discontinuity: players whose local date ≠ UTC date at play time get a different board today; per-day progress is keyed by date string, so nothing is lost or corrupted.

## Verification
- `npm test`: 66/66 (unchanged from baseline)
- Playwright harness driving the real launcher iframe pool (opaque sandbox, bridged storage), 5/5:
  - the exact editor-status toast call renders in the launcher's `#launcher-toast`
  - `getDailyDateString()` === `Arcade.daily.dateStr()`; offsets still work
  - `recordGameEnd(7)`, `recordGameEnd(4)`, `recordPuzzleSolved(true/false)` land in launcher storage as `{gamesPlayed: 2, bestCombo: 7, puzzlesSolved: 2, dailiesSolved: 1}` — bestCombo doesn't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)