### PR TITLE
Add Arcade.audio SFX + Arcade.records per-mode best scores (G4)

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -19,6 +19,7 @@ import {
 } from './specials.js';
 import { onStarflowerCreated } from './puzzle-mode.js';
 import { getPlayerName, recordGameEnd } from './storage.js';
+import { sfx } from './audio.js';
 
 function prepopulateNameInputs() {
   const name = getPlayerName();
@@ -512,6 +513,7 @@ export async function handleGameOver(ctx, isSessionEnd = false) {
   const combinedId = ctx.getCombinedModeId();
   ctx.clearGameState(combinedId);
   recordGameEnd(getMaxCombo());
+  sfx('game-over'); // covers bomb explosion and chill session end
   // Score is committed when the user confirms their name in modal-gameover
   // (or already committed by btn-confirm-end before this runs, for chill).
 

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,0 +1,85 @@
+/**
+ * audio.js — Sound effects via the managed Arcade.audio SFX engine.
+ *
+ * Single registration site (A1): all cues are registered once at module import,
+ * which happens right after `Arcade.init({ gameId })` in index.html's <head>.
+ * All play-sites go through the `sfx()` wrapper (A2), which feature-detects the
+ * SDK so a stale launcher-served SDK (or standalone with an old cache) degrades
+ * to silence instead of throwing.
+ *
+ * Hecknsic has no in-game sound toggle and does not add one (A3) — the launcher
+ * owns volume + the global mute button, and Arcade.audio honours both for us.
+ *
+ * Palette: arcade-y square / sawtooth voices, all cues short (≤0.25s) and
+ * conservative gain (≤0.35) per A5. NOTE: sound aesthetics need a human ear pass.
+ */
+
+// ─── Cue registrations (A1 — one site) ──────────────────────────────
+// Register only when the SDK's audio surface exists; harmless no-op otherwise.
+if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
+  // Per-rotation press blip — one short tick per player rotation (not per step).
+  Arcade.audio.cue('rotate', { type: 'square', freq: 330, dur: 0.05, gain: 0.16 });
+
+  // A match group clears (first clear of a cascade).
+  Arcade.audio.cue('match', { type: 'square', freq: 520, dur: 0.09, gain: 0.26 });
+
+  // Chained cascade step — freq is overridden per-play (comboFreq) to step the
+  // pitch up with chain depth.
+  Arcade.audio.cue('combo', { type: 'sawtooth', freq: 440, dur: 0.10, gain: 0.26 });
+
+  // Shared celebratory sparkle for special-piece formation (starflower / black
+  // pearl / grand poobah) — a quick two-voice arpeggio up.
+  Arcade.audio.cue('special', [
+    { type: 'square', freq: 660, dur: 0.08, gain: 0.30 },
+    { type: 'square', freq: 990, dur: 0.12, gain: 0.30 },
+  ]);
+
+  // A bomb is queued to appear on the board — low, tense saw thud.
+  Arcade.audio.cue('bomb', { type: 'sawtooth', freq: 120, dur: 0.18, gain: 0.30 });
+
+  // Game over / session end — descending three-voice saw motif.
+  Arcade.audio.cue('game-over', [
+    { type: 'sawtooth', freq: 330, dur: 0.14, gain: 0.30 },
+    { type: 'sawtooth', freq: 220, dur: 0.16, gain: 0.30 },
+    { type: 'sawtooth', freq: 110, dur: 0.22, gain: 0.30, release: 0.08 },
+  ]);
+
+  // Soft UI tick for menu / button interactions.
+  Arcade.audio.cue('ui-click', { type: 'square', freq: 440, dur: 0.03, gain: 0.12 });
+}
+
+// ─── Play wrapper (A2 — single guarded call site) ───────────────────
+export const sfx = (name, opts) => {
+  if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
+    Arcade.audio.play(name, opts);
+  }
+};
+
+/**
+ * Rising pitch for the 'combo' cue as chain depth increases. Semitone-ish steps
+ * off A4, capped so deep cascades stay inside the audible/legal freq range.
+ * @param {number} depth — chain level (1, 2, 3, …)
+ */
+export function comboFreq(depth) {
+  const steps = Math.min(Math.max(depth, 0), 15);
+  return Math.round(440 * Math.pow(2, steps / 12));
+}
+
+/**
+ * Play a soft 'ui-click' on menu / button interactions. Uses one delegated
+ * capture-phase listener so it fires even for handlers that stopPropagation,
+ * and stays off the canvas + rotate arrows (those get their own 'rotate' cue).
+ */
+export function wireUiClicks() {
+  if (typeof document === 'undefined') return;
+  const SELECTOR =
+    '.icon-btn, .start-btn, .dropdown-btn, .hand-toggle, .game-hud-restart, .game-hud-logo';
+  document.addEventListener(
+    'click',
+    (e) => {
+      const el = e.target;
+      if (el && el.closest && el.closest(SELECTOR)) sfx('ui-click');
+    },
+    true,
+  );
+}

--- a/js/main.js
+++ b/js/main.js
@@ -60,8 +60,10 @@ import {
   saveGameState, loadGameState, clearGameState,
   addHighScore, getHighScores,
   getPlayerName, setPlayerName,
-  loadSettings, saveSettings
+  loadSettings, saveSettings,
+  recordModeScore, seedRecordsFromScores,
 } from './storage.js';
+import { sfx, comboFreq, wireUiClicks } from './audio.js';
 import {
   initPuzzleModeUI, showPuzzleSelector, registerPuzzleCallbacks,
   clearActivePuzzle, getActivePuzzle, getPuzzleMovesLeft,
@@ -545,6 +547,12 @@ window.addEventListener('resize', () => {
 // Restore active mode then load per-mode saved state
 loadActiveMode();
 
+// One-shot: seed the per-mode best-score records from existing leaderboards so
+// long-time players keep their history (idempotent). Then wire the soft
+// ui-click cue onto menu/button interactions.
+seedRecordsFromScores();
+wireUiClicks();
+
 // Puzzle mode is transient (board state isn't persisted), so it can't be
 // meaningfully restored on reload.  Fall back to arcade.
 if (getActiveGameModeId() === 'puzzle') {
@@ -825,6 +833,7 @@ function resetBoardForNewMode() {
 async function animateRotation(clockwise) {
   if (state !== 'selected') return;
   state = 'rotating';
+  sfx('rotate'); // one blip per player rotation press (not per internal step)
   const gen = boardGeneration;
   const ctx = getAnimationContext();
 
@@ -913,7 +922,10 @@ async function postRotationCheck(gen) {
       const currentScore = getScore();
       let dynamicInterval = 15 - Math.floor(currentScore / 5000);
       if (dynamicInterval < 4) dynamicInterval = 4;
-      if (moveCount % dynamicInterval === 0) bombQueued = true;
+      if (moveCount % dynamicInterval === 0 && !bombQueued) {
+        bombQueued = true;
+        sfx('bomb'); // a bomb is about to appear on the board
+      }
     }
   }
 
@@ -938,6 +950,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
+      sfx('special'); // grand poobah formed
       await animateGrandPoobahCreation(ctx, gpResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -950,6 +963,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
+      sfx('special'); // black pearl formed
       await animateBlackPearlCreation(ctx, bpResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -962,6 +976,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
+      sfx('special'); // starflower formed
       await animateStarflowerCreation(ctx, sfResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -970,10 +985,15 @@ async function postRotationCheck(gen) {
 
     const matches = findMatchesForMode(grid, activeCols, activeRows);
     if (matches.size > 0) {
-      if (!isFirstStep) { advanceChain(); await delay(100); }
+      const chained = !isFirstStep;
+      if (chained) { advanceChain(); await delay(100); }
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
+      // First clear = plain match; chained cascade steps = combo, pitch rising
+      // with chain depth via a per-play freq override.
+      if (chained) sfx('combo', { freq: comboFreq(getChainLevel()) });
+      else sfx('match');
       await runCascade(ctx, matches, gen);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -1100,7 +1120,10 @@ function setNameFromInput(inputId) {
  *  for the active game mode. Call once per game-over flow before resetGame. */
 function commitScoreFromInput(inputId, achievement) {
   setNameFromInput(inputId);
-  addHighScore(getActiveGameModeId(), getScore(), achievement, getMaxCombo());
+  const modeId = getActiveGameModeId();
+  addHighScore(modeId, getScore(), achievement, getMaxCombo());
+  // Records: single best-ever score per mode, alongside the leaderboard (R4).
+  recordModeScore(modeId, getScore());
 }
 
 function clustersMatch(a, b) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -135,6 +135,51 @@ export function recordPuzzleSolved(isDaily) {
   }));
 }
 
+// ─── Records (Arcade.records) — per-mode single best score ──────
+// One self-describing best-ever value per score-accumulating mode, rendered by
+// the launcher's Records sheet with zero in-game code. These live ALONGSIDE the
+// per-mode Arcade.scores leaderboards (R4) — the boards stay a ranked top-N with
+// names; the record is the single "best ever" framing.
+//
+// Only arcade + chill accumulate a mode-wide score (finalised via
+// commitScoreFromInput → addHighScore). Puzzle mode tracks bests per-puzzle
+// (savePuzzleProgress), not one mode aggregate, so it gets no record category
+// here — that would be a per-puzzle category explosion (capped at 50 by R4).
+const RECORD_SCORE_MODES = { arcade: 'Arcade', chill: 'Chill' };
+
+/**
+ * Promote a finalised mode score to its single-best record. Idempotent (best()
+ * never regresses; ties don't write). Feature-detected (R5) so a stale SDK is a
+ * no-op. Category slug is permanent schema: `best_score_<mode>`.
+ */
+export function recordModeScore(modeId, score) {
+  if (!(window.Arcade && Arcade.records)) return;
+  const modeLabel = RECORD_SCORE_MODES[modeId];
+  if (!modeLabel || !Number.isFinite(score)) return;
+  Arcade.records.best(`best_score_${modeId}`, {
+    value: score,
+    direction: 'higher',
+    format: 'integer',
+    label: `Best score — ${modeLabel}`,
+  });
+}
+
+/**
+ * One-shot seed of the records categories from the existing per-mode
+ * leaderboards, so long-time players don't lose their best. Idempotent via
+ * best(); guarded so a records-less SDK leaves the migration unmarked and
+ * retries after a later SDK upgrade.
+ */
+export function seedRecordsFromScores() {
+  if (!(window.Arcade && Arcade.records)) return;
+  Arcade.state.migrate('records-v1', () => {
+    for (const modeId of Object.keys(RECORD_SCORE_MODES)) {
+      const top = Arcade.scores.list(modeId, { limit: 1 })[0];
+      if (top && Number.isFinite(top.score)) recordModeScore(modeId, top.score);
+    }
+  });
+}
+
 // ─── Player name (cross-game, lives at arcade.v1.global.playerName) ──
 
 export function getPlayerName() {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.3.1';
+const APP_VERSION = '1.4.0';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets
@@ -11,6 +11,7 @@ const STATIC_ASSETS = [
   './manifest.json',
   './css/style.css',
   './css/overlays.css',
+  './js/audio.js',
   './js/board.js',
   './js/constants.js',
   './js/daily-puzzle.js',


### PR DESCRIPTION
Part of the fleet fan-out **Arcade.records + Arcade.audio adoption (2026-07)** — package **G4 (hecknsic)**. Plan: `plans/fleet-records-audio-2026-07.md` in the launcher repo (§2 conventions, §3 G4). Additive only — no launcher/SDK changes; both features are pure API calls against the launcher-served SDK (≥3.5.0). No issue to close.

## Audio (new `js/audio.js`)
- One registration site (A1), one feature-detected `sfx()` wrapper (A2). No in-game toggle added (A3) — the launcher owns volume + global mute, and `Arcade.audio` honours both.
- Arcade-y square/saw palette, every cue `dur ≤ 0.25s`, `gain ≤ 0.35` (A5).
- Cues on discrete player-meaningful events only (A7).

**Cue list:**
| cue | spec | fired at |
| --- | --- | --- |
| `rotate` | square 330Hz 0.05s | once per rotation press (`animateRotation`) |
| `match` | square 520Hz 0.09s | first match group clears |
| `combo` | sawtooth, base 440Hz, **per-play `freq` override** rising with chain depth (`comboFreq`) | each chained cascade step |
| `special` | square 2-voice 660→990Hz | starflower / black-pearl / grand-poobah formation (one shared cue) |
| `bomb` | sawtooth 120Hz 0.18s | a bomb is queued to appear |
| `game-over` | sawtooth 3-voice 330→220→110Hz descending | `handleGameOver` (bomb explosion + chill session end) |
| `ui-click` | square 440Hz 0.03s | delegated onto menu buttons (`.icon-btn`, `.start-btn`, `.dropdown-btn`, …; excludes canvas + rotate arrows) |

**Sound aesthetics need a human ear pass** — the implementing agent cannot listen (A5).

## Records (per-mode best score, alongside the scores boards — R4)
Written at the single score-finalisation funnel (`commitScoreFromInput` → after `addHighScore`), seeded from the existing per-mode leaderboards via `migrate('records-v1')`. Always `direction` + `format` + `label`; `best()` not `set()`; feature-detected (R5).

| category (permanent slug) | direction | format | label |
| --- | --- | --- | --- |
| `best_score_arcade` | higher | integer | Best score — Arcade |
| `best_score_chill` | higher | integer | Best score — Chill |

The existing per-mode `Arcade.scores` boards are unchanged (R4).

## Release (P2)
- `sw.js` `APP_VERSION` `1.3.1` → `1.4.0`
- `js/audio.js` added to `STATIC_ASSETS`

## Verify
- `npm test` (node --test): **66 pass / 0 fail** (unchanged from baseline).
- Syntax-checked all changed modules; audio module smoke-tested in node (degrades to no-op when `window`/`Arcade` absent; `comboFreq` steps 440→523→…→1047 capped).
- Acceptance run + Records sheet check + human ear pass are the plan-owner review gate (launcher `dev.sh` not started — shared port, concurrent agents).

## Deviations from the package sketch
- **No "best daily streak" record.** The package says "plus best daily streak *if stats already track it*" — the code tracks only `dailiesSolved` (a counter) and `bestCombo` in `lifetime` stats; no daily *streak* is stored, so nothing to promote (didn't invent the metric).
- **Puzzle mode gets no per-mode score record.** Puzzle scoring is per-puzzle (`savePuzzleProgress` `bestScore`), not one mode aggregate; promoting it would be a per-puzzle category explosion (capped at 50, R4). The mode-wide score records therefore cover the two score-accumulating modes: arcade + chill.
- `bestCombo` is a genuine tracked single-best and could later become a `best_combo` record, but that's outside the G4 scope (per-mode best score + daily streak); left out to avoid scope creep (P3). Noting it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)