### PR TITLE
Fix offline reload on loopback hosts

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.4.0';
+const APP_VERSION = '1.4.1';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets
@@ -53,9 +53,6 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-  // Skip caching on localhost — always serve fresh files during development.
-  if (self.location.hostname === 'localhost' || self.location.hostname === '127.0.0.1') return;
-
   // Cache-first for all GET requests — serves static assets offline.
   if (event.request.method !== 'GET') return;
 
@@ -63,6 +60,27 @@ self.addEventListener('fetch', (event) => {
   // assets like /arcade-sdk.js get cached under our origin-wide fetch handler
   // and a stale SDK is served indefinitely.
   if (!event.request.url.startsWith(self.registration.scope)) return;
+
+  const isLoopback = self.location.hostname === 'localhost' || self.location.hostname === '127.0.0.1';
+
+  if (isLoopback) {
+    // Network-first on localhost: prefer fresh files during development
+    // (no stale-cache surprises while iterating without a version bump),
+    // but still fall back to cache when actually offline, so this worker
+    // exercises real offline behavior instead of stepping aside entirely.
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          if (response && response.status === 200 && response.type !== 'opaque') {
+            const cloned = response.clone();
+            caches.open(CACHE_VERSION).then((cache) => cache.put(event.request, cloned));
+          }
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
 
   event.respondWith(
     caches.match(event.request).then((cached) => {


### PR DESCRIPTION
The SW fully bypassed itself on `localhost`/`127.0.0.1` (a dev convenience to avoid stale cache), which meant real offline behavior was never exercised on loopback — only in production. Switches the loopback path to network-first-with-cache-fallback instead of a hard bypass: still fresh while online, but now correctly falls back to cache when the network fetch fails, matching how the SW behaves in production.

Found via the launcher's `tools/acceptance.mjs` §13 offline-reload check, which failed only for hecknsic among the fleet (the other two SW-bearing games, pi-game and sow-duku, never had this bypass).

`npm test`: 66/66. Acceptance check 10 (offline reload): now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)