### PR TITLE
Sync docs with shipped Arcade.audio + Arcade.records

### DIFF
--- a/docs/Dev_Plan.md
+++ b/docs/Dev_Plan.md
@@ -11,7 +11,7 @@ A clean, phase-gated blueprint to recreate the speed and vibe of Hecknsic HD as 
 | **Rendering** | HTML5 Canvas 2D | Zero dependencies, fast for 2D, easy bevel/gradient effects |
 | **Language** | Vanilla JS (ES6+ modules) | No build step, `<script type="module">` |
 | **Structure** | Single `index.html` + module files | Serve from any static host |
-| **Audio** | Web Audio API | Beat analysis, spatial SFX, no libs needed |
+| **Audio** | Managed `Arcade.audio` SFX (launcher SDK 3.5.0+) | Short synth cues only — no beat analysis, no spatial audio, no music (see §2 note) |
 | **Multiplayer** | WebRTC DataChannel | P2P, low latency, no game server |
 | **Signaling** | QR code exchange (`qrcode-generator` + camera scan) | No central server required |
 
@@ -36,13 +36,16 @@ js/
   score.js           ← points, chain multiplier, level
   specials.js        ← star, flower, bomb creation + activation
   tween.js           ← lightweight easing helper (~40 lines)
-  audio.js           ← music, SFX, beat detection
+  audio.js           ← SFX cue registrations + play wrapper, via Arcade.audio
   multiplayer.js     ← WebRTC, QR signaling, state sync
   ui.js              ← HUD overlays (score, combo, pause)
-assets/
-  sounds/            ← match.wav, rotate.wav, combo.wav, etc.
-  music/             ← background track(s)
 ```
+
+> **Note (2026-07-21):** shipped audio is short synth cues via the
+> launcher's managed `Arcade.audio` — no `assets/sounds/`, no
+> `assets/music/`, no beat detection. Background music was descoped (see
+> §5's development-phases checklist below); the `assets/` tree this
+> section originally sketched was never built.
 
 ---
 
@@ -216,8 +219,8 @@ Each hex is drawn as a 6-sided polygon with:
   - Visual: shockwave ring + debris particles
 - [ ] **Obstacle pieces** (stone): immovable, cleared only by adjacent matches or specials
 - [ ] Particle system: simple canvas-drawn circles with velocity + fade for match/explosion FX
-- [ ] Sound effects: rotate click, match chime (pitch rises with chain length), combo whoosh, special activation
-- [ ] Background music: Web Audio API playback, optional BPM detection for pulsing hex brightness
+- [x] Sound effects: rotate click, match chime (pitch rises with chain length via per-play `freq` override), special activation — shipped 2026-07-21 via `Arcade.audio` (`js/audio.js`)
+- [ ] Background music: **descoped** — no music/beat-detection layer was built; the shipped audio is short discrete SFX cues only
 - [ ] Level progression: increase color count or add obstacles as score milestones are reached
 - [ ] Game-over condition: no valid moves remaining → show final score
 

--- a/docs/gameplay-feedback.md
+++ b/docs/gameplay-feedback.md
@@ -6,8 +6,8 @@ I would like to add a couple items on the todo list regarding gameplay.
 
 - The rotation buttons should show the key binded to that direction, to make the ui more intuitive
 
-- A simple and robust settings system utilizing browser cookies.  This would hold app settings like theme (dark/light), sound controls, rotation button mapping, high score, and other stateful needs.  
+- A simple and robust settings system utilizing browser cookies.  This would hold app settings like theme (dark/light), ~~sound controls~~, rotation button mapping, ~~high score~~, and other stateful needs. (Sound controls: done, via the launcher's global mute/volume, not an in-game cookie setting. High score: done for single-value bests via `Arcade.records` — see note below.)
 
 - Use cookies (or other client-based storage option) to store game board state, to enable a game to persist accross page refreshes.
 
-- Game history with high scores list 
+- Game history with high scores list (partially addressed — `Arcade.records` now tracks a single best-per-mode value (`best_score_arcade`/`best_score_chill`), not a ranked history list; still open if a history list is wanted)

--- a/docs/gamerules.md
+++ b/docs/gamerules.md
@@ -107,11 +107,18 @@ The game will be structured into modular components to ensure maintainability an
 * **Player Management Module**:  
   * Manages player states and actions in both single and multiplayer modes.  
   * Handles player-specific data like scores and current power-ups.  
-* **Graphics and Audio Module**:  
+* **Graphics and Audio Module** *(superseded — see note below)*:  
   * Manages rendering to the canvas (using PixiJS/Phaser).  
   * Handles visual effects for matches, special pieces, and power-ups.  
   * Synchronizes visual pulsing/vibration with game music.  
   * Manages sound effects and background music.
+
+> **Note (2026-07-21):** this is an early speculative spec superseded by
+> the actual build in several respects — rendering is Canvas 2D directly
+> (no PixiJS/Phaser, per `Dev_Plan.md`), and audio is short synth SFX cues
+> via the launcher's `Arcade.audio` (`js/audio.js`), with no background
+> music or beat-sync. High scores are tracked via `Arcade.records`
+> (per-mode single best), not a dedicated scoring module.
 
 ### **3.3 Game Loop and Rendering**
 


### PR DESCRIPTION
Doc-only. Three docs described audio (beat analysis, background music, a \`sounds/\`/\`music/\` asset tree) and a high-score module that the shipped implementation doesn't match — actual audio is short synth cues via the launcher's managed \`Arcade.audio\` (\`js/audio.js\`), and high scores are now per-mode \`Arcade.records\` bests. Updates \`Dev_Plan.md\`, \`gameplay-feedback.md\`, and \`gamerules.md\` to match, marking background music explicitly descoped rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)