### PR TITLE
Re-tune SFX: struck glass on a dark board, not chiptune

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -10,42 +10,78 @@
  * Hecknsic has no in-game sound toggle and does not add one (A3) — the launcher
  * owns volume + the global mute button, and Arcade.audio honours both for us.
  *
- * Palette: arcade-y square / sawtooth voices, all cues short (≤0.25s) and
- * conservative gain (≤0.35) per A5. NOTE: sound aesthetics need a human ear pass.
+ * Sound identity: struck glass on a dark board. The board is glassy coloured
+ * gems, not an 8-bit cabinet, so tile events ring rather than beep — a short
+ * noise strike transient followed by a triangle/sine fundamental with a bright
+ * upper partial (the 3rd harmonic, a twelfth above) doing the shimmer, decaying
+ * out over the whole tail. Rotation is the one *mechanical* act in the game
+ * (tiles physically turning), so it is a dry ratchet click: noise plus a
+ * pitch-dropping square blip, not a tone. Sawtooth is reserved for `bomb`, the
+ * only destructive event, so it reads as materially unlike the glass around it.
+ * Energy stays arcade — everything is short, snappy and bright; only the
+ * material changed. Envelopes stay conservative: dur ≤0.25s, gain ≤0.35, and
+ * summed simultaneous voices stay well under 1.0 (the SDK master has no
+ * limiter). NOTE: sound aesthetics need a human ear pass.
  */
 
 // ─── Cue registrations (A1 — one site) ──────────────────────────────
 // Register only when the SDK's audio surface exists; harmless no-op otherwise.
 if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
   // Per-rotation press blip — one short tick per player rotation (not per step).
-  Arcade.audio.cue('rotate', { type: 'square', freq: 330, dur: 0.05, gain: 0.16 });
+  // Mechanical ratchet detent: a noise scrape under a square blip whose pitch
+  // drops across its 26ms, which reads as a click/thunk rather than a beep.
+  Arcade.audio.cue('rotate', [
+    { type: 'noise', dur: 0.018, gain: 0.09, attack: 0.001, release: 0.016, delay: 0 },
+    { type: 'square', freq: 380, toFreq: 300, dur: 0.026, gain: 0.10, attack: 0.001, release: 0.024, delay: 0 },
+  ]);
 
-  // A match group clears (first clear of a cascade).
-  Arcade.audio.cue('match', { type: 'square', freq: 520, dur: 0.09, gain: 0.26 });
+  // A match group clears (first clear of a cascade). Struck glass: strike tick,
+  // C5 body, and the 3rd-harmonic shimmer on top, all decaying together. This
+  // fires constantly, so it is the loudness reference for the whole file — the
+  // three voices peak at 0.36 summed, still less energy than the old square.
+  Arcade.audio.cue('match', [
+    { type: 'noise', dur: 0.015, gain: 0.05, attack: 0.001, release: 0.013, delay: 0 },
+    { type: 'triangle', freq: 523, dur: 0.14, gain: 0.24, attack: 0.002, release: 0.125, delay: 0 },
+    { type: 'sine', freq: 1568, dur: 0.10, gain: 0.07, attack: 0.002, release: 0.095, delay: 0 },
+  ]);
 
   // Chained cascade step — freq is overridden per-play (comboFreq) to step the
-  // pitch up with chain depth.
-  Arcade.audio.cue('combo', { type: 'sawtooth', freq: 440, dur: 0.10, gain: 0.26 });
+  // pitch up with chain depth. MUST stay a single spec object: Arcade.audio
+  // merges per-play overrides onto object cues only, and ignores them on arrays.
+  // Triangle puts it in the glass family; the rising ladder sells the escalation.
+  Arcade.audio.cue('combo', { type: 'triangle', freq: 440, dur: 0.11, gain: 0.26, attack: 0.002, release: 0.095 });
 
   // Shared celebratory sparkle for special-piece formation (starflower / black
-  // pearl / grand poobah) — a quick two-voice arpeggio up.
+  // pearl / grand poobah) — the same strike tick as `match`, then a crystalline
+  // sine arpeggio rolled at 50ms so the notes overlap into a ringing chord, with
+  // a longer tail on top. Rare and celebratory, so it is the biggest cue here.
   Arcade.audio.cue('special', [
-    { type: 'square', freq: 660, dur: 0.08, gain: 0.30 },
-    { type: 'square', freq: 990, dur: 0.12, gain: 0.30 },
+    { type: 'noise', dur: 0.012, gain: 0.05, attack: 0.001, release: 0.010, delay: 0 },
+    { type: 'sine', freq: 660, dur: 0.09, gain: 0.22, attack: 0.002, release: 0.08, delay: 0 },
+    { type: 'sine', freq: 990, dur: 0.09, gain: 0.22, attack: 0.002, release: 0.08, delay: 0.05 },
+    { type: 'sine', freq: 1320, dur: 0.16, gain: 0.20, attack: 0.002, release: 0.145, delay: 0.05 },
   ]);
 
-  // A bomb is queued to appear on the board — low, tense saw thud.
-  Arcade.audio.cue('bomb', { type: 'sawtooth', freq: 120, dur: 0.18, gain: 0.30 });
+  // A bomb is queued to appear on the board — the one destructive event, and the
+  // only place sawtooth survives: a noise rumble under a saw thud sagging
+  // 120→80Hz, deliberately unlike the glass everything else is made of.
+  Arcade.audio.cue('bomb', [
+    { type: 'noise', dur: 0.15, gain: 0.12, attack: 0.005, release: 0.13, delay: 0 },
+    { type: 'sawtooth', freq: 120, toFreq: 80, dur: 0.18, gain: 0.28, attack: 0.005, release: 0.15, delay: 0 },
+  ]);
 
-  // Game over / session end — descending three-voice saw motif.
+  // Game over / session end — descending three-voice motif, played back-to-back.
+  // Triangle keeps it in-palette; gains rise as it descends because a low
+  // triangle carries far less perceived weight than the saw it replaces.
   Arcade.audio.cue('game-over', [
-    { type: 'sawtooth', freq: 330, dur: 0.14, gain: 0.30 },
-    { type: 'sawtooth', freq: 220, dur: 0.16, gain: 0.30 },
-    { type: 'sawtooth', freq: 110, dur: 0.22, gain: 0.30, release: 0.08 },
+    { type: 'triangle', freq: 330, dur: 0.14, gain: 0.30, release: 0.05 },
+    { type: 'triangle', freq: 220, dur: 0.16, gain: 0.32, release: 0.06 },
+    { type: 'triangle', freq: 110, dur: 0.24, gain: 0.34, release: 0.14 },
   ]);
 
-  // Soft UI tick for menu / button interactions.
-  Arcade.audio.cue('ui-click', { type: 'square', freq: 440, dur: 0.03, gain: 0.12 });
+  // Soft UI tick for menu / button interactions — a tiny high glass "tink", and
+  // deliberately the quietest cue in the file.
+  Arcade.audio.cue('ui-click', { type: 'triangle', freq: 880, dur: 0.025, gain: 0.10, attack: 0.001, release: 0.022 });
 }
 
 // ─── Play wrapper (A2 — single guarded call site) ───────────────────

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.4.1';
+const APP_VERSION = '1.4.2';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets


### PR DESCRIPTION
**Sound identity: struck glass on a dark board** — tile events ring like a tapped gem (strike transient + triangle/sine body + a bright upper partial), rotation is a dry mechanical ratchet click, and sawtooth survives only on `bomb`, the one destructive event.

### Why

The `Arcade.audio` adoption gave every fleet game one of two generic palettes (sine/triangle = gentle, square/sawtooth = arcade). Hecknsic landed in the arcade bucket. That *fits* an arcade game, but fitting a bucket is not the same as having your own sound — `match` (square 520) and `rotate` (square 330) were literally the same voice at two pitches, and nothing in the file said *glassy hexagon tiles on black*. This changes the material and keeps the energy: every cue is still short, snappy and bright.

### Per-cue before → after

| Cue | Before | After | Intent |
|---|---|---|---|
| `rotate` | `square 330, dur .05, gain .16` | `noise (.018/.09)` + `square 380→300, dur .026, gain .10` | Rotation is the one *mechanical* act — tiles physically turning. Ratchet detent click, not a beep. The pitch sag is what makes it read as a click. |
| `match` | `square 520, dur .09, gain .26` | `noise tick (.015/.05)` + `triangle 523, dur .14, gain .24` + `sine 1568, dur .10, gain .07` | Struck glass: strike, C5 body, 3rd-harmonic shimmer, all decaying together. |
| `combo` | `sawtooth 440, dur .10, gain .26` | `triangle 440, dur .11, gain .26` — **still a single spec object** | Into the glass family. Stays single-voice because `comboFreq()` drives the chain-depth ladder via a per-play `{freq}` override, and array cues ignore overrides. |
| `special` | `square 660` → `square 990`, gain .30 | `noise tick` + `sine 660 / 990 / 1320` rolled at `delay .05`, gains .22/.22/.20 | Crystalline arpeggio that overlaps into a ringing chord, longer tail on top. Rare cue, so it's the biggest one here. |
| `bomb` | `sawtooth 120, dur .18, gain .30` | `noise (.15/.12)` + `sawtooth 120→80, dur .18, gain .28` | Deliberately keeps saw. The only destructive event; should feel materially unlike the glass tiles. |
| `game-over` | 3× `sawtooth` 330/220/110, gain .30 | 3× `triangle` 330/220/110, gains .30/.32/.34 | Same descending shape, in-palette. |
| `ui-click` | `square 440, dur .03, gain .12` | `triangle 880, dur .025, gain .10` | Tiny high glass "tink"; still the quietest cue in the file. |

### Deviations from the spec draft (and why)

The spec's code blocks were informed drafts nobody had heard. I kept the direction and adjusted numbers in four places:

1. **`rotate` gets a pitch sag** (`freq: 380, toFreq: 300` instead of a flat `square 330`). The brief asked for "click/ratchet, not beep", but a flat 330Hz square held for 30ms is ~10 cycles — that is still audibly a low beep. A fast downward ramp is the standard way to make a short pitched voice read as percussive. Noise nudged .08 → .09 to give the detent some grit.
2. **`match` loudness.** Raised the body .22 → .24 and the shimmer .06 → .07. The warning about stacking three voices is right in the abstract, but the replaced voice was a *square* — a triangle at .24 carries roughly half the RMS energy of a square at .26, so this is a net loudness **decrease** despite tripling the voice count. Peak summed amplitude is 0.36; the SDK master gain has no limiter, so I checked every cue sums well under 1.0 (worst case is `special` at ~0.69 momentarily).
3. **`special` gains a strike tick** and drops .24/.24/.22 → .22/.22/.20, with the top note's tail extended .14 → .16. The tick is the same one `match` uses; sharing it is what makes the two cues sound like the same *material* rather than two unrelated sounds, which is the whole point of the re-tune. The gain trim offsets the fact that the rolled arpeggio overlaps into a chord rather than playing back-to-back.
4. **`game-over` gains step up as it descends** (.30/.32/.34 rather than a flat .30). Equal-loudness: a triangle at 110Hz is close to inaudible next to the sawtooth it replaces, so a flat gain would have made the motif fade out instead of landing.

All voices remain within `dur ≤ 0.25s` and `gain ≤ 0.35`.

### Structure & scope

Unchanged: one registration block, one `sfx()` wrapper, `wireUiClicks()` and `comboFreq()` untouched, no cue renames, no new game events, no in-game sound toggle (the launcher owns volume + mute). The module header comment previously described the two-bucket plan convention; it now describes the actual sound identity and technique.

### Version bump

`sw.js` `APP_VERSION` **1.4.1 → 1.4.2** (`js/audio.js` is a cached static asset, so cached clients need the new `CACHE_VERSION`). `package.json` is **not** touched by hand — `git log -p -- package.json` shows it is exclusively auto-bumped by `geebs-bot` in `chore: auto-bump to vX [skip ci]` commits, so bumping it here would fight the bot.

### Verification

`npm test` → **66/66 pass**. No dev server was started.

> [!IMPORTANT]
> **This audio has not been heard by anyone.** Every number here is reasoned from waveform energy, envelope shape and equal-loudness, not from listening. That is why this is a draft — it needs an ear pass before merge. The likeliest things to be wrong on first listen: `match` sitting too quiet now that it is a triangle, and `rotate`'s noise layer reading as hiss rather than as a mechanical detent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
