### PR TITLE
Glass sound pack: shatter, ratchet and a floor that breathes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules/
 .idea/
 *.log
 .go.pid
+.arcade-stage/

--- a/ago
+++ b/ago
@@ -14,6 +14,8 @@
 # Layout produced under .arcade-stage/ :
 #   index.html         (launcher, URLs rewritten)
 #   arcade-sdk.js      (rewritten)
+#   arcade-*.js        (SDK + all companion modules, incl. the audio element
+#                       library; without it the game falls back to chiptune)
 #   styles.css, profile.html, manifest.json, images/ (from launcher repo)
 #   hecknsic/          (this repo's static files, SDK URL rewritten)
 #
@@ -117,11 +119,21 @@ mkdir -p "$STAGE_DIR"
 
 # Launcher files: copy with absolute → local-origin rewrite.
 # Skip sw.js — SW caching hides edits during dev.
-for f in index.html profile.html manifest.json arcade-sdk.js styles.css; do
-  src="$LAUNCHER_DIR/$f"
-  if [ -f "$src" ]; then
-    sed "s|https://paulgibeault.github.io|$LOCAL_ORIGIN|g" "$src" > "$STAGE_DIR/$f"
-  fi
+#
+# Every arcade-*.js is staged by glob rather than by name. arcade-sdk.js pulls
+# in a growing set of companion modules at runtime (records, save, catalog,
+# leaderboard, sync, the audio element library, …), and a hardcoded list falls
+# silently behind the SDK: the page loads, then 404s a dozen modules and the
+# launcher UI comes up broken. Globbing means ago tracks the SDK automatically.
+#
+# catalog.json is the launcher's authoritative game list; without it the shelf
+# boots empty and logs a catalog 404.
+for src in "$LAUNCHER_DIR"/index.html "$LAUNCHER_DIR"/profile.html \
+           "$LAUNCHER_DIR"/manifest.json "$LAUNCHER_DIR"/styles.css \
+           "$LAUNCHER_DIR"/catalog.json "$LAUNCHER_DIR"/arcade-*.js; do
+  [ -f "$src" ] || continue
+  f="$(basename "$src")"
+  sed "s|https://paulgibeault.github.io|$LOCAL_ORIGIN|g" "$src" > "$STAGE_DIR/$f"
 done
 
 # Defang the launcher's service-worker registration so dev pages stay fresh.

--- a/docs/audio-overhaul.md
+++ b/docs/audio-overhaul.md
@@ -8,16 +8,18 @@ silence.
 
 ## Status
 
-Shipped. `js/soundpack.js` was written against audition v1
+Shipped and ear-passed. `js/soundpack.js` was written against audition v1
 (`tools/soundpack/render.mjs hecknsic` in the launcher repo, 4:47, peaks
-≤0.83); retuning happens against a re-render, not against the wired game.
+≤0.83) and approved by ear at that version — no retune was needed. Any future
+change is auditioned the same way: re-render, listen, quote a timestamp. Do
+not retune against the wired game.
 
 | phase | state |
 |---|---|
 | 1. Framework elements (`shatter`, `ratchet`, `drone`) in `../paulgibeault.github.io/arcade-audio.js` | done |
 | 2. `js/soundpack.js` — 14 cues, 2 beds, 3 material tables | done |
 | 3. Audition timeline + rendered WAV | done |
-| 4. Ear pass / tuning loop | **open — retune the pack, re-render, repeat** |
+| 4. Ear pass / tuning loop | done — v1 approved as rendered, no retune needed |
 | 5. `js/audio.js` two-path rewrite | done |
 | 6. Call-site wiring, `index.html`, `sw.js`, `ago` | done |
 | 7. Verification | done — see below |
@@ -43,12 +45,10 @@ Shipped. `js/soundpack.js` was written against audition v1
 
 ### Known gaps
 
-- The pack has not had its ear pass. That is phase 4 and it is the point of the
-  audition workflow — quote a timestamp from the INDEX, retune, re-render.
 - `render.mjs` documents reproducibility as a design goal, but only the pack
   code is seeded; Chromium's convolver render varies by ~1 LSB between runs.
-  Worth a separate launcher issue — it makes checksum-based regression testing
-  of sound packs impossible.
+  Filed as paulgibeault/paulgibeault.github.io#98 — it makes checksum-based
+  regression testing of sound packs impossible.
 - The same `ago` staging gap fixed here (hardcoded launcher file list falling
   behind the SDK) exists in moon-lit's `ago`.
 
@@ -113,7 +113,7 @@ fade-in/out, `collect`-aware). Symmetric detuned pair beats at a rate set by
 `type` ('sine'), `sub` octave-down level (0), `lp` (500) + drift LFO (`drift`
 0.06 Hz, `driftAmt`), `gain`, `fade` (1.5), `collect`.
 
-## Audition workflow (phase 4 — the loop we are in)
+## Audition workflow
 
 ```bash
 cd ../paulgibeault.github.io

--- a/docs/audio-overhaul.md
+++ b/docs/audio-overhaul.md
@@ -1,0 +1,217 @@
+# hecknsic audio overhaul — design + implementation plan
+
+Modelled on moon-lit's audio overhaul (moon-lit PRs #25/#28): physical-gesture
+synthesis via the launcher's shared element library, a game-owned sound pack,
+an offline-rendered audition WAV approved by ear BEFORE wiring, and a two-path
+registration module so stale caches degrade to the old chiptune rather than
+silence.
+
+## Status
+
+Shipped. `js/soundpack.js` was written against audition v1
+(`tools/soundpack/render.mjs hecknsic` in the launcher repo, 4:47, peaks
+≤0.83); retuning happens against a re-render, not against the wired game.
+
+| phase | state |
+|---|---|
+| 1. Framework elements (`shatter`, `ratchet`, `drone`) in `../paulgibeault.github.io/arcade-audio.js` | done |
+| 2. `js/soundpack.js` — 14 cues, 2 beds, 3 material tables | done |
+| 3. Audition timeline + rendered WAV | done |
+| 4. Ear pass / tuning loop | **open — retune the pack, re-render, repeat** |
+| 5. `js/audio.js` two-path rewrite | done |
+| 6. Call-site wiring, `index.html`, `sw.js`, `ago` | done |
+| 7. Verification | done — see below |
+
+### Verified
+
+- **moon-lit is untouched by the shared-library change.** The renderer is not
+  bit-deterministic run to run, so checksums prove nothing here; measured
+  numerically instead. Two renders of *identical* code differ by 271 samples,
+  1 LSB peak, −140.3 dBFS RMS. Original vs patched `arcade-audio.js` differs by
+  266 samples, 1 LSB peak, −140.4 dBFS — indistinguishable from the renderer's
+  own noise floor, 109 dB under the signal.
+- **Graph path is live in the browser**, not silently falling back: the shared
+  room bus exists (only `room()` creates it) and `start('pulse')` returns a
+  handle carrying `retune`, which `setBedUrgency` depends on.
+- **All 19 cue invocations** the game can emit play without throwing, including
+  both parameter extremes of `match`, `combo` and `bomb-tick`.
+- **Adaptive retune** steps 0 → 0.35 → 0.7 → 1.0 cleanly on a live bed.
+- **Both registration paths** are pinned by `tests/audio.test.js`, including the
+  case the gate exists for: an element library with `graph()`/`el()` present but
+  missing any one of `shatter`/`ratchet`/`drone` must fall back rather than
+  throw mid-cue. 74 tests pass.
+
+### Known gaps
+
+- The pack has not had its ear pass. That is phase 4 and it is the point of the
+  audition workflow — quote a timestamp from the INDEX, retune, re-render.
+- `render.mjs` documents reproducibility as a design goal, but only the pack
+  code is seeded; Chromium's convolver render varies by ~1 LSB between runs.
+  Worth a separate launcher issue — it makes checksum-based regression testing
+  of sound packs impossible.
+- The same `ago` staging gap fixed here (hardcoded launcher file list falling
+  behind the SDK) exists in moon-lit's `ago`.
+
+## The design
+
+The place: **a dark room with a glass machine in it**. Board = saturated jewel
+glass on near-black (`#0a0b0e`). Identity decisions, all encoded in
+`js/soundpack.js`:
+
+- **Tiles are glass** — every clear is a granular `shatter` scaled by cluster
+  size; every formed piece *rings* (`body` with material-specific partial
+  tables: `GLASS`, `CHROME` for starflower, `OBSIDIAN` for black pearl).
+- **Rotation ratchets** — the one mechanical act. `ratchet` element,
+  decelerating detents (3 cluster / 4 pearl-Y / 6 starflower-ring), glass
+  seating knock. Fires per input → lives at `CONSTANT`, heavy per-play
+  variation.
+- **Formation = reversed shatter** — `skew < 1` runs the shard cloud as a
+  converging crescendo: glass assembling, not breaking. The three specials are
+  one gesture in three materials (chrome shimmer ↑ / obsidian mass ↓ / both).
+- **The bomb is an event chain** — `bomb-arrive` (impact + fuse flare +
+  beating dread pair), `bomb-tick` (per move, `urgency` 0..1 tightens it),
+  `bomb-explode` (`blast` with `tone` — the board as struck bell — plus two
+  outward shatter waves), then `game-over` (three obsidian tolls) ~0.8 s later.
+- **The floor breathes** — two sustained beds: `pulse` (non-metrical sub
+  heartbeat + 41 Hz drone; `intensity` per mode) and `tension` (beating drone
+  + subdividing tick; `urgency` tracks the nearest bomb fuse; schedules
+  *nothing* at 0). Deliberately not metrical: no tempo to fight the player's
+  pacing. If the ear pass wants a musical pulse instead, that changes only the
+  `pulse` function in the pack.
+
+Register plan (bands, so overlapping cues don't mask): pulse 30–90 Hz · bomb
+22–160 · ratchet pawl 200–1.4k · glass bodies 500–3k · shards 2.5–9k · UI
+tink 3–6k. Mix anchors: `CONSTANT = 0.026` (per-input), `FREQUENT = 0.055`
+(per-clear); everything else is balanced around those two.
+
+## New framework elements (shipped in `arcade-audio.js`)
+
+Additive only — moon-lit loads the same file. All follow library conventions:
+seeded `rng`, `env()` exponential envelopes, `collect`/`track` for sustained
+teardown.
+
+### `shatter(ctx, dest, t, p)` → dur
+Brittle fracture. Grain cloud synthesized into **one buffer per call** (like
+`pluck`/`creak` — never N live oscillators). Params: `dur` (0.45), `grains`
+(42), `f0` base shard freq (3200; log-uniform spread ±[−0.8,+1.4] octaves),
+`bright` freq scale, `skew` grain-time exponent (2.2; **>1 front-loads =
+breaking, <1 rear-loads = converging formation**), `ring` per-shard decay
+scale, `crack` 0..1 leading fracture strikes (1), `hp` highpass under the
+cloud (1500), `gain`, `seed`.
+
+### `ratchet(ctx, dest, t, p)` → dur
+Pawl over gear teeth — regular machined detents (vs `creak`'s irregular
+stick-slip). Per detent: strike + 2-partial pawl `body`, jittered. Params:
+`detents` (5), `dur` (0.35), `end` = last/first interval ratio (**>1
+decelerates, <1 accelerates**), `f` pawl freq (640), `hp` (2600), `jitter`
+(0.07), `gain`, `seed`, `collect`.
+
+### `drone(ctx, dest, t, dur, p)` → dur
+Sustained tonal pressure (tonal sibling of `stream`; explicit `dur`,
+fade-in/out, `collect`-aware). Symmetric detuned pair beats at a rate set by
+`detune` cents (**≤5 breathes, ≥30 dread**). Params: `f` (55), `detune` (8),
+`type` ('sine'), `sub` octave-down level (0), `lp` (500) + drift LFO (`drift`
+0.06 Hz, `driftAmt`), `gain`, `fade` (1.5), `collect`.
+
+## Audition workflow (phase 4 — the loop we are in)
+
+```bash
+cd ../paulgibeault.github.io
+node tools/soundpack/render.mjs hecknsic            # → tools/soundpack/out/hecknsic-v1.wav + INDEX.md
+node tools/soundpack/render.mjs hecknsic --version v2   # after edits, keep v1 for A/B
+```
+
+The INDEX.md timestamps are exact — feedback arrives as "1:12 too bright";
+edit `js/soundpack.js` (or the elements), re-render, diff by ear. The renderer
+injects the *shipped* `arcade-audio.js`, so an approved audition is
+bit-identical to what plays. v1 rendered 2026-07-26: 4:47, peaks ≤0.83, no
+clipping.
+
+## Phase 5 — `js/audio.js` rewrite (spec)
+
+Follow `../moon-lit/js/sfx.js` **exactly** in shape: single registration site
+(A1), guarded play-wrapper (A2), launcher owns volume/mute (A3), kebab-case
+event-shaped names (A4).
+
+- **Graph path** gate: `Arcade.audio.graph`, `.room`, `.start`, `.el()` all
+  present AND every `NEEDED_ELEMENTS` entry is a function:
+  `['strike','rustle','body','thump','flare','blast','shatter','ratchet','drone','teardown']`.
+  On success: `a.room(HecknsicPack.ROOM)`, register each `CUES` entry with its
+  `SENDS`, register `pulse`/`tension` with `{ sustained: true, send: 0.30 / 0.35 }`,
+  set `graphMode = true`.
+- **Fallback path**: the CURRENT chiptune cues, preserved **verbatim** as the
+  archive (rotate, match, combo, special, bomb, game-over, ui-click — see git
+  history of this file). A stale SW cache gets the old sound, never silence,
+  never console noise.
+- **Exports** (superset of today's, so call sites stay one-line):
+  - `sfx(name, opts)` — unchanged guard.
+  - `playRotate(kind)` — graph: `sfx('rotate', {kind})`; fallback: `sfx('rotate')`.
+  - `playSelect()` — graph-only; fallback no-op (old profile had no cue).
+  - `playMatch(count)` / `playCombo(depth)` — graph: params through; fallback:
+    `sfx('match')` / `sfx('combo', {freq: comboFreq(depth)})` (keep
+    `comboFreq` for the fallback only).
+  - `playSpecial(type)` — graph: `sfx(type)` for
+    `'starflower'|'blackpearl'|'grandpoobah'`; fallback: `sfx('special')`.
+  - `playBombArrive()` — graph: `'bomb-arrive'`; fallback: `'bomb'`.
+  - `playBombTick(urgency)` — graph-only; fallback no-op.
+  - `playBombExplode()` — graph: `'bomb-explode'`; fallback no-op (the old
+    profile folded the explosion into `game-over`, which still fires).
+  - `playGameOver(isSessionEnd)` — graph: if `!isSessionEnd` play
+    `'bomb-explode'` then `'game-over'` ~0.8 s later (`setTimeout` is fine —
+    launcher mute makes late play a no-op); else `'game-over'` alone.
+    Fallback: `sfx('game-over')` once, as today.
+  - `playOverAchiever()`, `playGameWin()` — graph: own cues; fallback:
+    `'game-over'` → keep silence for these two instead (they had no archived
+    sound; a wrong-mood cue is worse than none).
+  - `startBed()` / `stopBed(fade)` / `setBedUrgency(u)` — see below.
+  - `wireUiClicks()` — unchanged.
+- **Beds**: `startBed()` idempotent, graph-gated, `a.start('pulse', { dur: 420,
+  intensity })` where intensity = 0.6 arcade / 0.25 chill / 0.4 puzzle (from
+  `getActiveGameModeId()` — pass it in rather than importing modes.js into
+  audio.js if that creates a cycle). `tension` starts at urgency 0 alongside.
+  `setBedUrgency(u)` retunes the tension handle only (never the pulse), using
+  moon-lit's quantised-steps-with-hysteresis pattern verbatim: steps
+  `[0, 0.35, 0.7, 1.0]`, up `[0.30, 0.58, 0.84]`, down `[0.20, 0.48, 0.74]`,
+  crossfade 2.0 s; no-op when `retune` is missing (pre-3.7.0 SDK). `stopBed`
+  on game over / restart / mode switch; also call `startBed()` from the first
+  user-gesture path so autoplay policy is satisfied.
+
+## Phase 6 — call-site wiring (exact map)
+
+| site | today | becomes |
+|---|---|---|
+| `js/main.js:836` (`animateRotation`) | `sfx('rotate')` | `playRotate(flowerCenter ? 'ring' : pearlCenter ? 'y' : 'cluster')` |
+| `js/main.js:721`, `:742`, `:760` (`state = 'selected'`) | silent | `playSelect()` (once per pickup, not per re-render) |
+| `js/main.js:907–918` bomb shake tween | visual only | before the tween: compute `minTimer` = min `bombTimer` over board; `playBombTick(clamp01(1 − (minTimer − 1) / 10))` |
+| `js/main.js:927` | `sfx('bomb')` | `playBombArrive()` |
+| `js/main.js:953` / `:966` / `:979` | `sfx('special')` ×3 | `playSpecial('grandpoobah' / 'blackpearl' / 'starflower')` |
+| `js/main.js:995–996` | `sfx('combo', {freq})` / `sfx('match')` | `playCombo(getChainLevel())` / `playMatch(matches.size)` |
+| `js/main.js:878` (`handleGameWin`) | silent | `playGameWin()` |
+| `js/animations.js:516` (`handleGameOver`) | `sfx('game-over')` | `playGameOver(isSessionEnd)` |
+| `js/animations.js:454` (`handleOverAchiever`) | silent | `playOverAchiever()` |
+| bed lifecycle | — | `startBed()` on game start/first input; `setBedUrgency(...)` at the end of `postRotationCheck` (same `minTimer` math; 0 when no bombs); `stopBed()` in game-over/over-achiever/reset paths |
+
+Plus:
+
+- **`index.html:15`** — after the SDK line add, matching moon-lit's comment style:
+  `<script src="/arcade-audio.js"></script>` then
+  `<script src="js/soundpack.js"></script>` (before the `js/main.js` module).
+- **`sw.js`** — add `./js/soundpack.js` to `STATIC_ASSETS`; bump
+  `APP_VERSION` (CI check `check-sw-bump` will demand it).
+- **`ago:120`** — the staged-launcher copy loop
+  (`for f in index.html profile.html manifest.json arcade-sdk.js styles.css`)
+  is missing `arcade-audio.js`; add it or local `ago` runs silently fall back
+  to chiptune. (moon-lit's `ago` has the same latent gap.)
+- **audio.js header** — remove the stale "sound aesthetics need a human ear
+  pass" note; the pack got one.
+
+## Phase 7 — verification
+
+1. `./ago`, open the game, confirm the console-free graph path registers
+   (temporarily `console.log(graphMode)` if needed — remove before commit).
+2. Exercise: select, rotate (cluster + starflower ring), match, cascade,
+   bomb spawn→tick→defuse and →explode, puzzle win, chill session end.
+3. Kill `/arcade-audio.js` from the stage once to prove the chiptune fallback
+   still plays.
+4. Launcher repo: `npm run check-sw-bump`; hecknsic tests in `tests/` still
+   pass (audio is import-inert without `window.Arcade`).

--- a/index.html
+++ b/index.html
@@ -13,6 +13,12 @@
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/overlays.css">
   <script src="/arcade-sdk.js"></script>
+  <!-- The shared physical-gesture element library, and this game's sound pack
+       built on it. Both are optional: if either is missing (a stale cached SDK,
+       or running standalone off the launcher origin), js/audio.js falls back to
+       the archived chiptune spec cues. -->
+  <script src="/arcade-audio.js"></script>
+  <script src="js/soundpack.js"></script>
   <script>
     Arcade.init({ gameId: 'hecknsic' });
 

--- a/js/animations.js
+++ b/js/animations.js
@@ -19,7 +19,7 @@ import {
 } from './specials.js';
 import { onStarflowerCreated } from './puzzle-mode.js';
 import { getPlayerName, recordGameEnd } from './storage.js';
-import { sfx } from './audio.js';
+import { playGameOver, playOverAchiever, stopBed } from './audio.js';
 
 function prepopulateNameInputs() {
   const name = getPlayerName();
@@ -453,6 +453,8 @@ export async function animateGrandPoobahCreation(ctx, gpResults) {
 
 export async function handleOverAchiever(ctx) {
   ctx.setState('gameover');
+  stopBed(1.5);
+  playOverAchiever();
   const combinedId = ctx.getCombinedModeId();
   ctx.clearGameState(combinedId);
   // Score is committed when the user confirms their name in modal-over-achiever.
@@ -513,7 +515,11 @@ export async function handleGameOver(ctx, isSessionEnd = false) {
   const combinedId = ctx.getCombinedModeId();
   ctx.clearGameState(combinedId);
   recordGameEnd(getMaxCombo());
-  sfx('game-over'); // covers bomb explosion and chill session end
+  // A real game over is two events: the detonation, then the aftermath tolls a
+  // beat behind it. A peaceful chill-session end is the tolls alone — nothing
+  // exploded. The floor drops away under both.
+  stopBed(1.5);
+  playGameOver(isSessionEnd);
   // Score is committed when the user confirms their name in modal-gameover
   // (or already committed by btn-confirm-end before this runs, for chill).
 

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,45 +1,293 @@
 /**
- * audio.js — Sound effects via the managed Arcade.audio SFX engine.
+ * audio.js — Sound for hecknsic, via the launcher SDK's managed `Arcade.audio`.
+ * This is the game's single audio module.
  *
- * Single registration site (A1): all cues are registered once at module import,
- * which happens right after `Arcade.init({ gameId })` in index.html's <head>.
- * All play-sites go through the `sfx()` wrapper (A2), which feature-detects the
- * SDK so a stale launcher-served SDK (or standalone with an old cache) degrades
- * to silence instead of throwing.
+ * Two registration paths live here:
  *
- * Hecknsic has no in-game sound toggle and does not add one (A3) — the launcher
- * owns volume + the global mute button, and Arcade.audio honours both for us.
+ *   GRAPH PATH (SDK 3.7.0's /arcade-audio.js loaded) — the real sound design.
+ *     js/soundpack.js holds the pack; every cue is a WebAudio node graph built
+ *     from physical-gesture elements (strike, body, thump, flare, blast, and
+ *     the shatter / ratchet / drone elements this game drove into the shared
+ *     library), and every cue feeds one shared convolution room so overlapping
+ *     sounds fuse into one place — a dark room with a glass machine in it —
+ *     instead of stacking into a pile. That pack was rendered to an audition
+ *     WAV and approved by ear — do not retune it from here.
  *
- * Sound identity: struck glass on a dark board. The board is glassy coloured
- * gems, not an 8-bit cabinet, so tile events ring rather than beep — a short
- * noise strike transient followed by a triangle/sine fundamental with a bright
- * upper partial (the 3rd harmonic, a twelfth above) doing the shimmer, decaying
- * out over the whole tail. Rotation is the one *mechanical* act in the game
- * (tiles physically turning), so it is a dry ratchet click: noise plus a
- * pitch-dropping square blip, not a tone. Sawtooth is reserved for `bomb`, the
- * only destructive event, so it reads as materially unlike the glass around it.
- * Energy stays arcade — everything is short, snappy and bright; only the
- * material changed. Envelopes stay conservative: dur ≤0.25s, gain ≤0.35, and
- * summed simultaneous voices stay well under 1.0 (the SDK master has no
- * limiter). NOTE: sound aesthetics need a human ear pass.
+ *     NO SYNTHESIS LIVES IN THIS GAME. Every gesture the pack is built from is
+ *     an element in the launcher's shared library, and the crossfade that makes
+ *     the bed adaptive is `handle.retune()` in the SDK. What belongs to
+ *     hecknsic is the design — which gestures, how loud, how far away, how
+ *     often — and that is all js/soundpack.js contains. A gesture this game
+ *     needs and the library lacks goes into the library.
+ *
+ *   FALLBACK PATH (older cached SDK/companion, or standalone without
+ *     /arcade-audio.js) — the archived chiptune profile, copied verbatim from
+ *     this file as it stood at 9169f43 ("Re-tune SFX: struck glass on a dark
+ *     board, not chiptune"). Single-spec cues: the only thing a pre-3.6.0
+ *     `Arcade.audio` can play. It exists because a player on a stale
+ *     service-worker cache should get the old sound rather than silence; that
+ *     is an expected state, not an error, so it is not logged. See
+ *     NEEDED_ELEMENTS below for what decides the path.
+ *
+ * Both paths register cue names the play-wrappers below know how to reach, so
+ * every call site in the game works unchanged either way — the wrappers, not
+ * the call sites, absorb the difference (the graph path splits `special` into
+ * three materially different formations, for instance, where the chiptune
+ * profile has one).
+ *
+ * Conventions (fleet Arcade.audio conventions, launcher GAME_INTEGRATION.md §5):
+ *   A1 — cues are registered ONCE here at module load. Audio is purely local,
+ *        so no `await Arcade.ready` is needed; the SDK's classic <script> +
+ *        `Arcade.init(...)` in index.html's <head> have already run by the time
+ *        this ES module evaluates, so `window.Arcade.audio` and
+ *        `window.HecknsicPack` are both present.
+ *   A2 — every play-site in the game goes through a wrapper below, which
+ *        feature-detects `Arcade.audio`. hecknsic has NO in-game sound
+ *        setting, so the wrappers are a pure feature detect.
+ *   A3 — the launcher owns volume + the global mute button; this module adds
+ *        no volume slider and no mute of its own. `play()` is free + silent
+ *        when the user has muted.
+ *   A4 — cue names are lowercase-kebab and event-shaped.
  */
 
-// ─── Cue registrations (A1 — one site) ──────────────────────────────
-// Register only when the SDK's audio surface exists; harmless no-op otherwise.
-if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
+const audio = () =>
+  (typeof window !== 'undefined' && window.Arcade && window.Arcade.audio)
+    ? window.Arcade.audio
+    : null;
+
+const pack = () =>
+  (typeof window !== 'undefined' && window.HecknsicPack) ? window.HecknsicPack : null;
+
+// ─── ambient beds ───────────────────────────────────────────────────────────
+// The floor of the room, as two sustained cues on different clocks: the pulse,
+// which only depends on the mode, and the tension, which answers how close the
+// nearest bomb fuse is. Keeping them separate means the tension can be retuned
+// without restarting the pulse, which would put an audible seam under the
+// game's tensest moment.
+const PULSE_CUE = 'pulse';
+const TENSION_CUE = 'tension';
+const PULSE_SEND = 0.30;
+const TENSION_SEND = 0.35;
+// Each bed schedules its whole timeline in one pass, so this is how long a
+// single start() lasts before it fades out on its own. Well past any hecknsic
+// session; the beds are stopped at game over long before it matters.
+const BED_SECONDS = 420;
+
+// How busy the floor is per mode. Chill is nearly still; arcade leans in.
+const MODE_INTENSITY = { arcade: 0.6, chill: 0.25, puzzle: 0.4 };
+
+// Urgency, quantised. The tension layer can only change by being re-scheduled,
+// so this has to be a handful of steps rather than a continuous value — and the
+// steps need hysteresis, because a board with two bombs on different fuses
+// crosses back and forth over a threshold as they are cleared and respawned.
+// Rising uses UP[i], falling uses the lower DOWN[i], so a board sitting near a
+// boundary stays put.
+const URGENCY_STEPS = [0, 0.35, 0.7, 1.0];
+const URGENCY_UP = [0.30, 0.58, 0.84];
+const URGENCY_DOWN = [0.20, 0.48, 0.74];
+const URGENCY_CROSSFADE = 2.0;
+
+// True once the graph path has registered successfully. Everything only the
+// graph path can do (the beds, the split formations, the bomb chain) keys off
+// this.
+let graphMode = false;
+
+// ─── the play wrappers (A2) ─────────────────────────────────────────────────
+// Silent no-ops when Arcade.audio is absent, or when the launcher has muted
+// (the SDK short-circuits before touching the AudioContext).
+
+export function sfx(name, opts) {
+  const a = audio();
+  if (a) a.play(name, opts);
+}
+
+/** Rotation — the ratchet. `kind` picks the mechanism's size:
+ *  'ring' (starflower, 6 tiles), 'y' (black pearl), 'cluster' (the default 3). */
+export function playRotate(kind) {
+  if (graphMode) sfx('rotate', { kind: kind || 'cluster' });
+  else sfx('rotate');
+}
+
+/** Picking a cluster up. Graph path only — the chiptune profile has no cue for
+ *  it, and a borrowed one at this rate would be a tick on every touch. */
+export function playSelect() {
+  if (graphMode) sfx('select');
+}
+
+/** First clear of a cascade. `count` = tiles cleared, which scales the
+ *  fracture: more shards, longer, deeper — a bigger break, not a louder one. */
+export function playMatch(count) {
+  if (graphMode) sfx('match', { count });
+  else sfx('match');
+}
+
+/** A chained cascade step. `depth` climbs the ladder — the graph cue pitches
+ *  the glass ring and brightens the shards together; the chiptune cue keeps the
+ *  archived per-play `freq` override (single-spec cues only — the SDK ignores
+ *  overrides on array cues, which is why the archive's 'combo' is one voice). */
+export function playCombo(depth) {
+  if (graphMode) sfx('combo', { depth });
+  else sfx('combo', { freq: comboFreq(depth) });
+}
+
+/** Special formation. The graph path gives each its own material — chrome
+ *  shimmer, obsidian weight, or both — where the archive has one shared cue. */
+export function playSpecial(type) {
+  if (graphMode && (type === 'starflower' || type === 'blackpearl' || type === 'grandpoobah')) {
+    sfx(type);
+  } else {
+    sfx('special');
+  }
+}
+
+/** A bomb arrives on the board. */
+export function playBombArrive() {
+  if (graphMode) sfx('bomb-arrive');
+  else sfx('bomb');
+}
+
+/** The fuse clock, one per move while a bomb is live. `urgency` 0..1 tightens
+ *  it. Graph path only: the archive has no tick, and repeating its 'bomb' cue
+ *  every move would be far too heavy. */
+export function playBombTick(urgency) {
+  if (graphMode) sfx('bomb-tick', { urgency });
+}
+
+/** Session end. On the graph path a real game over is the detonation and then,
+ *  a beat later, the aftermath tolls — two events, because the explosion and
+ *  the loss are not the same moment. A peaceful chill-session end is the tolls
+ *  alone. The archive folds both into its single descending motif.
+ *
+ *  The delayed second cue is fire-and-forget: if the player has muted or left
+ *  in the meantime, `play()` is already a silent no-op. */
+export function playGameOver(isSessionEnd) {
+  if (!graphMode) {
+    sfx('game-over');
+    return;
+  }
+  if (isSessionEnd) {
+    sfx('game-over');
+    return;
+  }
+  sfx('bomb-explode');
+  setTimeout(() => sfx('game-over'), 800);
+}
+
+/** Over-achiever — the game's triumph condition. Graph path only: the archive
+ *  never had a cue for it, and its descending game-over motif is exactly the
+ *  wrong mood. Silence is the better loss. */
+export function playOverAchiever() {
+  if (graphMode) sfx('over-achiever');
+}
+
+/** Puzzle solved. Graph path only, for the same reason as above. */
+export function playGameWin() {
+  if (graphMode) sfx('game-win');
+}
+
+let pulseHandle = null;
+let tensionHandle = null;
+let urgencyStep = 0;
+
+/** Start the ambient beds. Idempotent — safe to call from the input path on
+ *  every interaction, which is also what satisfies the browser's autoplay
+ *  policy (the first real user gesture is what unlocks the AudioContext).
+ *  A silent no-op on the fallback path and whenever audio is unavailable; it
+ *  must never throw, because the game loop and input handlers call it. */
+export function startBed(modeId) {
+  if (pulseHandle) return;
+  const a = audio();
+  if (!a || !graphMode || typeof a.start !== 'function') return;
+  const intensity = MODE_INTENSITY[modeId] == null ? MODE_INTENSITY.arcade : MODE_INTENSITY[modeId];
+  pulseHandle = a.start(PULSE_CUE, { dur: BED_SECONDS, intensity });
+  urgencyStep = 0;
+  tensionHandle = a.start(TENSION_CUE, { dur: BED_SECONDS, urgency: URGENCY_STEPS[0] });
+}
+
+/** Stop the beds, fading over `fade` seconds. Also idempotent. */
+export function stopBed(fade) {
+  const f = typeof fade === 'number' && fade > 0 ? fade : 1.2;
+  const handles = [pulseHandle, tensionHandle];
+  pulseHandle = null;
+  tensionHandle = null;
+  urgencyStep = 0;
+  for (const h of handles) {
+    if (!h) continue;
+    try { h.stop(f); } catch (e) { /* never throw at a play-site */ }
+  }
+}
+
+/** How pressed the player is, 0..1 — main.js derives it from the shortest live
+ *  bomb fuse. The tension layer answers: the beating drone tightens and the dry
+ *  tick subdivides faster, so the room itself leans in rather than a warning
+ *  sound being added on top.
+ *
+ *  A sustained cue schedules its whole timeline up front, so changing it means
+ *  running a second tension layer and fading the first out under it. The SDK
+ *  owns that (`handle.retune`, 3.7.0+) — the game says what should change and
+ *  how fast, not how to crossfade it. Only the tension is retuned; the pulse
+ *  underneath is untouched, so there is no seam.
+ *
+ *  Safe to call every move: quantisation and hysteresis above mean an actual
+ *  retune happens a handful of times per session at most. */
+export function setBedUrgency(urgency) {
+  // No retune on a pre-3.7.0 SDK: the bed simply stays at the density it
+  // started with. That is a quieter loss than any workaround, and this runs in
+  // the move path, so it must not throw.
+  if (!tensionHandle || typeof tensionHandle.retune !== 'function') return;
+  const u = typeof urgency === 'number' && isFinite(urgency) ? urgency : 0;
+
+  let step = urgencyStep;
+  while (step < URGENCY_STEPS.length - 1 && u >= URGENCY_UP[step]) step++;
+  while (step > 0 && u < URGENCY_DOWN[step - 1]) step--;
+  if (step === urgencyStep) return;
+  urgencyStep = step;
+
+  tensionHandle.retune({ dur: BED_SECONDS, urgency: URGENCY_STEPS[step] }, URGENCY_CROSSFADE);
+}
+
+// ─── registration ───────────────────────────────────────────────────────────
+
+function registerPack(a, p) {
+  // One room for the whole game: the dark interior the pack is set in.
+  a.room(p.ROOM);
+  Object.keys(p.CUES).forEach((name) => {
+    a.graph(name, p.CUES[name], { send: p.SENDS[name] });
+  });
+  // The beds are written in the SDK's own sustained-cue shape —
+  // fn(ctx, out, when, params, rnd) returning a teardown — so they register
+  // directly. There is no adapter here on purpose: an argument-order shim in
+  // the game is a small thing that quietly becomes the place bed behaviour
+  // accumulates.
+  a.graph(PULSE_CUE, p.pulse, { sustained: true, send: PULSE_SEND });
+  a.graph(TENSION_CUE, p.tension, { sustained: true, send: TENSION_SEND });
+}
+
+// ─── fallback: the archived chiptune profile ────────────────────────────────
+// Copied verbatim from this file at 9169f43, which froze the game's pre-graph
+// sound. Keep it in sync with that archive rather than editing it here — it is
+// what a player on a stale service-worker cache hears, and it was tuned as a
+// whole.
+//
+// Cue names the graph pack has that do not appear below: 'select', 'bomb-tick',
+// 'bomb-explode', 'over-achiever' and 'game-win'. Each is a deliberate silence
+// on this path rather than a borrowed voice — see the wrappers above for why.
+
+const COMBO_BASE_HZ = 440; // A4
+
+function registerChiptune(a) {
   // Per-rotation press blip — one short tick per player rotation (not per step).
   // Mechanical ratchet detent: a noise scrape under a square blip whose pitch
   // drops across its 26ms, which reads as a click/thunk rather than a beep.
-  Arcade.audio.cue('rotate', [
+  a.cue('rotate', [
     { type: 'noise', dur: 0.018, gain: 0.09, attack: 0.001, release: 0.016, delay: 0 },
     { type: 'square', freq: 380, toFreq: 300, dur: 0.026, gain: 0.10, attack: 0.001, release: 0.024, delay: 0 },
   ]);
 
   // A match group clears (first clear of a cascade). Struck glass: strike tick,
   // C5 body, and the 3rd-harmonic shimmer on top, all decaying together. This
-  // fires constantly, so it is the loudness reference for the whole file — the
-  // three voices peak at 0.36 summed, still less energy than the old square.
-  Arcade.audio.cue('match', [
+  // fires constantly, so it is the loudness reference for the whole profile.
+  a.cue('match', [
     { type: 'noise', dur: 0.015, gain: 0.05, attack: 0.001, release: 0.013, delay: 0 },
     { type: 'triangle', freq: 523, dur: 0.14, gain: 0.24, attack: 0.002, release: 0.125, delay: 0 },
     { type: 'sine', freq: 1568, dur: 0.10, gain: 0.07, attack: 0.002, release: 0.095, delay: 0 },
@@ -48,14 +296,12 @@ if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
   // Chained cascade step — freq is overridden per-play (comboFreq) to step the
   // pitch up with chain depth. MUST stay a single spec object: Arcade.audio
   // merges per-play overrides onto object cues only, and ignores them on arrays.
-  // Triangle puts it in the glass family; the rising ladder sells the escalation.
-  Arcade.audio.cue('combo', { type: 'triangle', freq: 440, dur: 0.11, gain: 0.26, attack: 0.002, release: 0.095 });
+  a.cue('combo', { type: 'triangle', freq: COMBO_BASE_HZ, dur: 0.11, gain: 0.26, attack: 0.002, release: 0.095 });
 
   // Shared celebratory sparkle for special-piece formation (starflower / black
   // pearl / grand poobah) — the same strike tick as `match`, then a crystalline
-  // sine arpeggio rolled at 50ms so the notes overlap into a ringing chord, with
-  // a longer tail on top. Rare and celebratory, so it is the biggest cue here.
-  Arcade.audio.cue('special', [
+  // sine arpeggio rolled at 50ms so the notes overlap into a ringing chord.
+  a.cue('special', [
     { type: 'noise', dur: 0.012, gain: 0.05, attack: 0.001, release: 0.010, delay: 0 },
     { type: 'sine', freq: 660, dur: 0.09, gain: 0.22, attack: 0.002, release: 0.08, delay: 0 },
     { type: 'sine', freq: 990, dur: 0.09, gain: 0.22, attack: 0.002, release: 0.08, delay: 0.05 },
@@ -65,40 +311,32 @@ if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
   // A bomb is queued to appear on the board — the one destructive event, and the
   // only place sawtooth survives: a noise rumble under a saw thud sagging
   // 120→80Hz, deliberately unlike the glass everything else is made of.
-  Arcade.audio.cue('bomb', [
+  a.cue('bomb', [
     { type: 'noise', dur: 0.15, gain: 0.12, attack: 0.005, release: 0.13, delay: 0 },
     { type: 'sawtooth', freq: 120, toFreq: 80, dur: 0.18, gain: 0.28, attack: 0.005, release: 0.15, delay: 0 },
   ]);
 
   // Game over / session end — descending three-voice motif, played back-to-back.
-  // Triangle keeps it in-palette; gains rise as it descends because a low
-  // triangle carries far less perceived weight than the saw it replaces.
-  Arcade.audio.cue('game-over', [
+  a.cue('game-over', [
     { type: 'triangle', freq: 330, dur: 0.14, gain: 0.30, release: 0.05 },
     { type: 'triangle', freq: 220, dur: 0.16, gain: 0.32, release: 0.06 },
     { type: 'triangle', freq: 110, dur: 0.24, gain: 0.34, release: 0.14 },
   ]);
 
   // Soft UI tick for menu / button interactions — a tiny high glass "tink", and
-  // deliberately the quietest cue in the file.
-  Arcade.audio.cue('ui-click', { type: 'triangle', freq: 880, dur: 0.025, gain: 0.10, attack: 0.001, release: 0.022 });
+  // deliberately the quietest cue in the profile.
+  a.cue('ui-click', { type: 'triangle', freq: 880, dur: 0.025, gain: 0.10, attack: 0.001, release: 0.022 });
 }
 
-// ─── Play wrapper (A2 — single guarded call site) ───────────────────
-export const sfx = (name, opts) => {
-  if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
-    Arcade.audio.play(name, opts);
-  }
-};
-
 /**
- * Rising pitch for the 'combo' cue as chain depth increases. Semitone-ish steps
- * off A4, capped so deep cascades stay inside the audible/legal freq range.
+ * Rising pitch for the chiptune 'combo' cue as chain depth increases.
+ * Semitone-ish steps off A4, capped so deep cascades stay inside the
+ * audible/legal freq range. Graph path does its own laddering in the pack.
  * @param {number} depth — chain level (1, 2, 3, …)
  */
 export function comboFreq(depth) {
   const steps = Math.min(Math.max(depth, 0), 15);
-  return Math.round(440 * Math.pow(2, steps / 12));
+  return Math.round(COMBO_BASE_HZ * Math.pow(2, steps / 12));
 }
 
 /**
@@ -119,3 +357,41 @@ export function wireUiClicks() {
     true,
   );
 }
+
+// ─── A1 — the single registration site ──────────────────────────────────────
+// Last in the file so every cue table above it is initialised. Runs once at
+// module load, before main.js evaluates.
+
+// The gestures and APIs the pack is built out of. A cached older SDK or element
+// library has `graph()` and `el()` but not these, and a missing element would
+// throw inside a cue at play time — a cue that half-plays is worse than the
+// fallback profile, so the whole graph path is gated on the pack's actual
+// dependencies rather than on a version number.
+const NEEDED_ELEMENTS = [
+  'strike', 'body', 'thump', 'flare', 'blast',
+  'shatter', 'ratchet', 'drone', 'teardown',
+];
+
+(function registerCues() {
+  const a = audio();
+  if (!a) return;
+
+  const p = pack();
+  const el = (a && typeof a.el === 'function') ? a.el() : null;
+  const graphable =
+    !!p &&
+    typeof a.graph === 'function' &&
+    typeof a.room === 'function' &&
+    typeof a.start === 'function' &&
+    el !== null &&
+    NEEDED_ELEMENTS.every((name) => typeof el[name] === 'function');
+
+  if (graphable) {
+    registerPack(a, p);
+    graphMode = true;
+  } else {
+    // Stale cached SDK, or standalone without /arcade-audio.js. Expected, not
+    // a bug — no console noise.
+    registerChiptune(a);
+  }
+})();

--- a/js/audio.js
+++ b/js/audio.js
@@ -10,42 +10,78 @@
  * Hecknsic has no in-game sound toggle and does not add one (A3) — the launcher
  * owns volume + the global mute button, and Arcade.audio honours both for us.
  *
- * Palette: arcade-y square / sawtooth voices, all cues short (≤0.25s) and
- * conservative gain (≤0.35) per A5. NOTE: sound aesthetics need a human ear pass.
+ * Sound identity: struck glass on a dark board. The board is glassy coloured
+ * gems, not an 8-bit cabinet, so tile events ring rather than beep — a short
+ * noise strike transient followed by a triangle/sine fundamental with a bright
+ * upper partial (the 3rd harmonic, a twelfth above) doing the shimmer, decaying
+ * out over the whole tail. Rotation is the one *mechanical* act in the game
+ * (tiles physically turning), so it is a dry ratchet click: noise plus a
+ * pitch-dropping square blip, not a tone. Sawtooth is reserved for `bomb`, the
+ * only destructive event, so it reads as materially unlike the glass around it.
+ * Energy stays arcade — everything is short, snappy and bright; only the
+ * material changed. Envelopes stay conservative: dur ≤0.25s, gain ≤0.35, and
+ * summed simultaneous voices stay well under 1.0 (the SDK master has no
+ * limiter). NOTE: sound aesthetics need a human ear pass.
  */
 
 // ─── Cue registrations (A1 — one site) ──────────────────────────────
 // Register only when the SDK's audio surface exists; harmless no-op otherwise.
 if (typeof window !== 'undefined' && window.Arcade && Arcade.audio) {
   // Per-rotation press blip — one short tick per player rotation (not per step).
-  Arcade.audio.cue('rotate', { type: 'square', freq: 330, dur: 0.05, gain: 0.16 });
+  // Mechanical ratchet detent: a noise scrape under a square blip whose pitch
+  // drops across its 26ms, which reads as a click/thunk rather than a beep.
+  Arcade.audio.cue('rotate', [
+    { type: 'noise', dur: 0.018, gain: 0.09, attack: 0.001, release: 0.016, delay: 0 },
+    { type: 'square', freq: 380, toFreq: 300, dur: 0.026, gain: 0.10, attack: 0.001, release: 0.024, delay: 0 },
+  ]);
 
-  // A match group clears (first clear of a cascade).
-  Arcade.audio.cue('match', { type: 'square', freq: 520, dur: 0.09, gain: 0.26 });
+  // A match group clears (first clear of a cascade). Struck glass: strike tick,
+  // C5 body, and the 3rd-harmonic shimmer on top, all decaying together. This
+  // fires constantly, so it is the loudness reference for the whole file — the
+  // three voices peak at 0.36 summed, still less energy than the old square.
+  Arcade.audio.cue('match', [
+    { type: 'noise', dur: 0.015, gain: 0.05, attack: 0.001, release: 0.013, delay: 0 },
+    { type: 'triangle', freq: 523, dur: 0.14, gain: 0.24, attack: 0.002, release: 0.125, delay: 0 },
+    { type: 'sine', freq: 1568, dur: 0.10, gain: 0.07, attack: 0.002, release: 0.095, delay: 0 },
+  ]);
 
   // Chained cascade step — freq is overridden per-play (comboFreq) to step the
-  // pitch up with chain depth.
-  Arcade.audio.cue('combo', { type: 'sawtooth', freq: 440, dur: 0.10, gain: 0.26 });
+  // pitch up with chain depth. MUST stay a single spec object: Arcade.audio
+  // merges per-play overrides onto object cues only, and ignores them on arrays.
+  // Triangle puts it in the glass family; the rising ladder sells the escalation.
+  Arcade.audio.cue('combo', { type: 'triangle', freq: 440, dur: 0.11, gain: 0.26, attack: 0.002, release: 0.095 });
 
   // Shared celebratory sparkle for special-piece formation (starflower / black
-  // pearl / grand poobah) — a quick two-voice arpeggio up.
+  // pearl / grand poobah) — the same strike tick as `match`, then a crystalline
+  // sine arpeggio rolled at 50ms so the notes overlap into a ringing chord, with
+  // a longer tail on top. Rare and celebratory, so it is the biggest cue here.
   Arcade.audio.cue('special', [
-    { type: 'square', freq: 660, dur: 0.08, gain: 0.30 },
-    { type: 'square', freq: 990, dur: 0.12, gain: 0.30 },
+    { type: 'noise', dur: 0.012, gain: 0.05, attack: 0.001, release: 0.010, delay: 0 },
+    { type: 'sine', freq: 660, dur: 0.09, gain: 0.22, attack: 0.002, release: 0.08, delay: 0 },
+    { type: 'sine', freq: 990, dur: 0.09, gain: 0.22, attack: 0.002, release: 0.08, delay: 0.05 },
+    { type: 'sine', freq: 1320, dur: 0.16, gain: 0.20, attack: 0.002, release: 0.145, delay: 0.05 },
   ]);
 
-  // A bomb is queued to appear on the board — low, tense saw thud.
-  Arcade.audio.cue('bomb', { type: 'sawtooth', freq: 120, dur: 0.18, gain: 0.30 });
+  // A bomb is queued to appear on the board — the one destructive event, and the
+  // only place sawtooth survives: a noise rumble under a saw thud sagging
+  // 120→80Hz, deliberately unlike the glass everything else is made of.
+  Arcade.audio.cue('bomb', [
+    { type: 'noise', dur: 0.15, gain: 0.12, attack: 0.005, release: 0.13, delay: 0 },
+    { type: 'sawtooth', freq: 120, toFreq: 80, dur: 0.18, gain: 0.28, attack: 0.005, release: 0.15, delay: 0 },
+  ]);
 
-  // Game over / session end — descending three-voice saw motif.
+  // Game over / session end — descending three-voice motif, played back-to-back.
+  // Triangle keeps it in-palette; gains rise as it descends because a low
+  // triangle carries far less perceived weight than the saw it replaces.
   Arcade.audio.cue('game-over', [
-    { type: 'sawtooth', freq: 330, dur: 0.14, gain: 0.30 },
-    { type: 'sawtooth', freq: 220, dur: 0.16, gain: 0.30 },
-    { type: 'sawtooth', freq: 110, dur: 0.22, gain: 0.30, release: 0.08 },
+    { type: 'triangle', freq: 330, dur: 0.14, gain: 0.30, release: 0.05 },
+    { type: 'triangle', freq: 220, dur: 0.16, gain: 0.32, release: 0.06 },
+    { type: 'triangle', freq: 110, dur: 0.24, gain: 0.34, release: 0.14 },
   ]);
 
-  // Soft UI tick for menu / button interactions.
-  Arcade.audio.cue('ui-click', { type: 'square', freq: 440, dur: 0.03, gain: 0.12 });
+  // Soft UI tick for menu / button interactions — a tiny high glass "tink", and
+  // deliberately the quietest cue in the file.
+  Arcade.audio.cue('ui-click', { type: 'triangle', freq: 880, dur: 0.025, gain: 0.10, attack: 0.001, release: 0.022 });
 }
 
 // ─── Play wrapper (A2 — single guarded call site) ───────────────────

--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,7 @@ import {
   GRID_COLS, GRID_ROWS,
   MATCH_FLASH_MS, GRAVITY_MS,
   ROTATION_POP_MS, ROTATION_SETTLE_MS,
-  BOMB_SPAWN_INTERVAL,
+  BOMB_SPAWN_INTERVAL, BOMB_INITIAL_TIMER,
 } from './constants.js';
 import {
   createGrid, rotateCluster, rotateRing,
@@ -63,7 +63,12 @@ import {
   loadSettings, saveSettings,
   recordModeScore, seedRecordsFromScores,
 } from './storage.js';
-import { sfx, comboFreq, wireUiClicks } from './audio.js';
+import {
+  wireUiClicks,
+  playRotate, playSelect, playMatch, playCombo, playSpecial,
+  playBombArrive, playBombTick, playGameWin,
+  startBed, stopBed, setBedUrgency,
+} from './audio.js';
 import {
   initPuzzleModeUI, showPuzzleSelector, registerPuzzleCallbacks,
   clearActivePuzzle, getActivePuzzle, getPuzzleMovesLeft,
@@ -632,15 +637,22 @@ function gameLoop(timestamp) {
     return;
   }
 
-  // Process input — only consume in states that can use it
+  // Process input — only consume in states that can use it.
+  //
+  // A consumed action is a genuine user gesture, which is also what unlocks the
+  // AudioContext under the browser's autoplay policy — so the ambient floor is
+  // started from here rather than at load, where it would be blocked. Both
+  // calls are idempotent and early-return once the bed is running.
   if (state === 'idle') {
     const action = consumeAction();
     if (action && action.type === 'select') {
+      startBed(getActiveGameModeId());
       trySelect();
     }
   } else if (state === 'selected') {
     const action = consumeAction();
     if (action) {
+      startBed(getActiveGameModeId());
       if (action.type === 'rotateCW' || action.type === 'rotateCCW') {
         animateRotation(action.type === 'rotateCW');
       } else if (action.type === 'select') {
@@ -719,6 +731,7 @@ function trySelect() {
         flowerCenter = null;
         selectedCluster = [{ col: hex.col, row: hex.row }, ...yHexes];
         state = 'selected';
+        playSelect();
         // Pearl center is the center hex pixel
         const cp = hexToPixel(hex.col, hex.row, originX, originY);
         setClusterCenterPx(cp.x, cp.y);
@@ -740,6 +753,7 @@ function trySelect() {
       pearlCenter = null;
       selectedCluster = [{ col: hex.col, row: hex.row }, ...nbrs];
       state = 'selected';
+      playSelect();
       // Flower center pixel
       const cp = hexToPixel(hex.col, hex.row, originX, originY);
       setClusterCenterPx(cp.x, cp.y);
@@ -758,6 +772,7 @@ function trySelect() {
     pearlCenter = null;
     selectedCluster = cluster;
     state = 'selected';
+    playSelect();
     // Compute centroid of the 3 cluster hexes
     const px = cluster.map(h => hexToPixel(h.col, h.row, originX, originY));
     setClusterCenterPx(
@@ -833,7 +848,10 @@ function resetBoardForNewMode() {
 async function animateRotation(clockwise) {
   if (state !== 'selected') return;
   state = 'rotating';
-  sfx('rotate'); // one blip per player rotation press (not per internal step)
+  // One ratchet per player rotation press, not per internal step. The
+  // mechanism's size follows what is actually turning: a starflower spins its
+  // six-tile ring, a black pearl its Y, everything else the plain 3-cluster.
+  playRotate(flowerCenter ? 'ring' : pearlCenter ? 'y' : 'cluster');
   const gen = boardGeneration;
   const ctx = getAnimationContext();
 
@@ -877,8 +895,32 @@ async function animateRotation(clockwise) {
 
 function handleGameWin() {
   state = 'gameover';
+  stopBed();
+  playGameWin();
   prepopulateNameInputs();
   document.getElementById('modal-gamewin').classList.remove('hidden');
+}
+
+/** How pressed the player is by bombs, 0..1, from the SHORTEST live fuse on the
+ *  board — that is the one that ends the game. Arcade bombs spawn at
+ *  BOMB_INITIAL_TIMER, so a fresh one sits near 0 and the last move before
+ *  detonation is 1; a puzzle bomb placed on a shorter fuse simply starts
+ *  further up the scale, which is the right reading. Returns 0 when the board
+ *  is clear, which is what silences the tension bed entirely.
+ *  @returns {number} */
+function bombUrgency() {
+  let min = Infinity;
+  for (let c = 0; c < activeCols; c++) {
+    for (let r = 0; r < activeRows; r++) {
+      const cell = grid[c]?.[r];
+      if (cell?.special === 'bomb' && typeof cell.bombTimer === 'number') {
+        if (cell.bombTimer < min) min = cell.bombTimer;
+      }
+    }
+  }
+  if (min === Infinity) return 0;
+  const u = 1 - (min - 1) / BOMB_INITIAL_TIMER;
+  return Math.max(0, Math.min(1, u));
 }
 
 /** Shared post-rotation logic: tick bombs, cascade or detect specials.
@@ -905,6 +947,9 @@ async function postRotationCheck(gen) {
       }
     }
     if (bombCells.length > 0) {
+      // The fuse clock, with the shake. Urgency tracks the SHORTEST live fuse,
+      // since that is the one about to end the game.
+      playBombTick(bombUrgency());
       await tween(250, t => {
         const shakeX = Math.sin(t * Math.PI * 6) * 4 * (1 - t);
         for (const b of bombCells) {
@@ -924,7 +969,7 @@ async function postRotationCheck(gen) {
       if (dynamicInterval < 4) dynamicInterval = 4;
       if (moveCount % dynamicInterval === 0 && !bombQueued) {
         bombQueued = true;
-        sfx('bomb'); // a bomb is about to appear on the board
+        playBombArrive(); // a bomb is about to appear on the board
       }
     }
   }
@@ -950,7 +995,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      sfx('special'); // grand poobah formed
+      playSpecial('grandpoobah');
       await animateGrandPoobahCreation(ctx, gpResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -963,7 +1008,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      sfx('special'); // black pearl formed
+      playSpecial('blackpearl');
       await animateBlackPearlCreation(ctx, bpResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -976,7 +1021,7 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      sfx('special'); // starflower formed
+      playSpecial('starflower');
       await animateStarflowerCreation(ctx, sfResults);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -990,10 +1035,10 @@ async function postRotationCheck(gen) {
       if (boardGeneration !== gen) return;
       isFirstStep = false;
       state = 'cascading';
-      // First clear = plain match; chained cascade steps = combo, pitch rising
-      // with chain depth via a per-play freq override.
-      if (chained) sfx('combo', { freq: comboFreq(getChainLevel()) });
-      else sfx('match');
+      // First clear = plain match, sized by how much glass broke; chained
+      // cascade steps = combo, climbing the ladder with chain depth.
+      if (chained) playCombo(getChainLevel());
+      else playMatch(matches.size);
       await runCascade(ctx, matches, gen);
       if (boardGeneration !== gen) return;
       boardStable = false;
@@ -1013,6 +1058,11 @@ async function postRotationCheck(gen) {
   }
 
   resetChain();
+
+  // The floor answers the board: the tension layer tracks the shortest live
+  // fuse and goes silent when there are none. Quantised + hysteresis inside,
+  // so calling it every move costs a retune only a handful of times a session.
+  setBedUrgency(bombUrgency());
 
   // Puzzle move tracking
   const activePuzzle = getActivePuzzle();
@@ -1056,7 +1106,13 @@ function resetGame() {
   selectedCluster = null;
   flowerCenter = null;
   pearlCenter = null;
-  
+
+  // A restart is a fresh room: drop the old floor and start one at the new
+  // mode's intensity. startBed() is idempotent, so the stop matters more than
+  // the start — without it a mode switch would leave the previous bed running.
+  stopBed(0.4);
+  startBed(getActiveGameModeId());
+
   document.getElementById('modal-gameover').classList.add('hidden');
   
   // Ensure we are unpaused and running

--- a/js/soundpack.js
+++ b/js/soundpack.js
@@ -1,0 +1,471 @@
+// hecknsic sound pack — the game's own sound design.
+//
+// Loaded as a plain script after /arcade-audio.js. js/audio.js registers
+// everything here with Arcade.audio; the launcher's tools/soundpack renderer
+// loads this same file to produce audition WAVs, so what gets approved by ear
+// is what plays.
+//
+// The place: a dark room with a glass machine in it. The board is saturated
+// jewel glass on near-black (#0a0b0e); the one mechanical act in the game is
+// the rotation, so the mechanism RATCHETS — precise metal detents, not wood
+// creak. Everything destructive shatters; everything formed rings. Under it
+// all, the room itself has a pulse: a slow sub heartbeat that leans in when
+// bombs are on the board. Where moon-lit was discrete events over silence,
+// hecknsic is discrete glass over a floor that breathes.
+//
+// The room is small and hard-surfaced — short predelay, tight decay, and much
+// less top-shelf cut than an outdoor space, because glass IS its top end.
+//
+// Register plan, so simultaneous cues occupy different bands instead of
+// masking each other:
+//   pulse bed 30–90 · bomb boom/rumble 22–160 · ratchet pawl 200–1.4k
+//   glass bodies 500–3k · shatter shards 2.5–9k · UI tink 3–6k
+//
+// Every cue takes an `r` (seeded random stream) and varies pitch, timing and
+// layer balance per play. The rotate ratchet matters most: it fires on every
+// single input, and a mechanism that makes the same noise every turn stops
+// being furniture and starts being a beep.
+
+(function (global) {
+  'use strict';
+  const S = global.ArcadeAudioElements;
+
+  // A small dark interior with hard walls. Reflections arrive almost at once
+  // and die fast; the shelf barely touches the top end because a dark room
+  // full of glass still glints. A long or dark tail would put the board
+  // outdoors, or in a cathedral — both wrong.
+  const ROOM = {
+    dur: 1.15,
+    decay: 0.30,
+    preDelay: 0.009,
+    wet: 0.5,
+    shelfHz: 7800,
+    shelfDb: -2.5,
+    seed: 4111,
+  };
+
+  // Struck gem glass — the material every ordinary tile is made of. Stretched
+  // inharmonic ratios (glass, unlike a string, is stiff), upper partials dying
+  // fast: a tap, a glint, gone.
+  const GLASS = [
+    { ratio: 1.00, gain: 1.00, decay: 0.55, detune: 4 },
+    { ratio: 2.32, gain: 0.55, decay: 0.30, detune: 6 },
+    { ratio: 4.25, gain: 0.28, decay: 0.16, detune: 8 },
+    { ratio: 6.63, gain: 0.13, decay: 0.09, detune: 10 },
+    { ratio: 9.38, gain: 0.06, decay: 0.05, detune: 12 },
+  ];
+
+  // Chrome — the starflower's silver. Same family as GLASS but energy shifted
+  // UP the series (the 2.76 partial outweighs the prime) and detuned harder,
+  // so the whole stack beats and shimmers instead of settling.
+  const CHROME = [
+    { ratio: 1.00, gain: 0.90, decay: 0.90, detune: 6 },
+    { ratio: 2.76, gain: 1.00, decay: 0.70, detune: 9 },
+    { ratio: 5.40, gain: 0.50, decay: 0.45, detune: 12 },
+    { ratio: 8.93, gain: 0.25, decay: 0.28, detune: 14 },
+    { ratio: 13.34, gain: 0.10, decay: 0.15, detune: 16 },
+  ];
+
+  // Obsidian — the black pearl. Materially the inverse of CHROME: nearly
+  // harmonic (dense volcanic glass rings almost pure), nearly no upper
+  // partials, and a decay three times GLASS's. Dark, smooth, heavy.
+  const OBSIDIAN = [
+    { ratio: 1.00, gain: 1.00, decay: 1.90, detune: 3 },
+    { ratio: 2.01, gain: 0.40, decay: 1.10, detune: 4 },
+    { ratio: 3.02, gain: 0.15, decay: 0.55, detune: 5 },
+    { ratio: 5.19, gain: 0.05, decay: 0.20, detune: 8 },
+  ];
+
+  // How much of the room each cue sits in. The ratchet is under your fingers
+  // and stays nearly dry; the specials bloom out into the space; the bomb owns
+  // the whole room when it goes.
+  const SENDS = {
+    'rotate': 0.14,
+    'select': 0.15,
+    'match': 0.30,
+    'combo': 0.34,
+    'starflower': 0.45,
+    'blackpearl': 0.40,
+    'grandpoobah': 0.50,
+    'bomb-arrive': 0.38,
+    'bomb-tick': 0.22,
+    'bomb-explode': 0.55,
+    'over-achiever': 0.55,
+    'game-win': 0.50,
+    'game-over': 0.48,
+    'ui-click': 0.10,
+  };
+
+  // The two mix anchors, same discipline as moon-lit. CONSTANT is anything
+  // that fires on every input (rotate, select): texture you could not swear
+  // you heard. FREQUENT is the per-clear family (match, combo): present, but
+  // it repeats many times a minute, so it must never announce itself.
+  const CONSTANT = 0.026;
+  const FREQUENT = 0.055;
+
+  const clamp01 = (x) => Math.max(0, Math.min(1, typeof x === 'number' && isFinite(x) ? x : 0));
+
+  // A tiny glass knock — the tile family's contact sound, used wherever a
+  // piece seats or is touched. Two partials only: a full GLASS body at knock
+  // level just reads as another match.
+  function knock(ctx, o, t, r, f0, gain, collect) {
+    S.strike(ctx, o, t, { dur: 0.004, hp: S.between(r, 1200, 1700), gain: gain * 0.8, seed: (r() * 1e6) | 0, collect });
+    S.body(ctx, o, t, {
+      f0: f0 * S.cents(r, 30), gain,
+      partials: [
+        { ratio: 1.0, gain: 1.0, decay: S.between(r, 0.04, 0.07), detune: 5 },
+        { ratio: 2.32, gain: 0.3, decay: S.between(r, 0.02, 0.04), detune: 8 },
+      ],
+      collect,
+    });
+  }
+
+  const CUES = {
+    // The rotation mechanism. Glass tiles, but the AXLE is machined metal:
+    // discrete pawl detents, decelerating (`end` > 1) because a hand settles a
+    // dial rather than spinning it, ending on the glass knock of the cluster
+    // seating in its new orientation. Fires on every press → CONSTANT, and
+    // every turn pulls its own pawl pitch, brightness, detent count wobble and
+    // seating weight so no two turns agree.
+    //
+    // p.kind: 'cluster' (3 detents) | 'y' (4) | 'ring' (6, longer — the
+    // starflower turns six tiles at once and the mechanism has more to move).
+    'rotate': function (ctx, o, t, p, r) {
+      const kind = p && p.kind;
+      const detents = kind === 'ring' ? 6 : kind === 'y' ? 4 : 3;
+      const dur = kind === 'ring' ? S.between(r, 0.40, 0.50) : S.between(r, 0.22, 0.30);
+      S.ratchet(ctx, o, t, {
+        detents, dur,
+        f: S.between(r, 520, 700), hp: S.between(r, 2200, 3000),
+        end: S.between(r, 1.6, 2.2),
+        gain: CONSTANT * S.between(r, 0.85, 1.15),
+        jitter: 0.08, seed: (r() * 1e6) | 0,
+      });
+      // the cluster dropping into its detent — glass on glass, quiet, and not
+      // every time: sometimes the mechanism just stops
+      if (r() < 0.9) {
+        knock(ctx, o, t + dur + 0.015, r, S.between(r, 300, 380), CONSTANT * S.between(r, 0.7, 1.0));
+      }
+      return dur + 0.18;
+    },
+
+    // Picking a cluster up: the three tiles lift, three micro-tinks a few
+    // hundredths apart, rising slightly. Barely there — this and rotate are
+    // the whole per-input texture of the game.
+    'select': function (ctx, o, t, p, r) {
+      const n = Math.min((p && p.tiles) || 3, 3);
+      let at = t;
+      for (let i = 0; i < n; i++) {
+        S.body(ctx, o, at, {
+          f0: S.between(r, 950, 1350) * (1 + 0.06 * i), gain: CONSTANT * 0.55,
+          partials: [
+            { ratio: 1.0, gain: 1.0, decay: 0.07, detune: 5 },
+            { ratio: 2.32, gain: 0.25, decay: 0.04, detune: 8 },
+          ],
+        });
+        at += S.between(r, 0.014, 0.026);
+      }
+      return 0.2;
+    },
+
+    // A match clearing — the tiles SHATTER. Cluster size scales the fracture,
+    // not just the level: more shards, a longer cloud, and a base pitch that
+    // sits lower (bigger panes ring deeper), plus the struck ring of the glass
+    // that broke. p.count = tiles cleared (3..10+).
+    'match': function (ctx, o, t, p, r) {
+      const count = Math.max(3, ((p && p.count) | 0) || 3);
+      const size = Math.min(count, 10);
+      const sc = 1 + (size - 3) * 0.13;              // 3 → 1.0, 10 → ~1.9
+      S.shatter(ctx, o, t, {
+        dur: 0.30 * sc, grains: Math.round(26 * sc),
+        f0: 3400 / Math.sqrt(sc),
+        skew: 2.3, crack: 0.8, hp: 1600,
+        gain: FREQUENT * (0.80 + 0.06 * (size - 3)),
+        seed: (r() * 1e6) | 0,
+      });
+      S.body(ctx, o, t + 0.004, {
+        f0: (S.between(r, 700, 780) / Math.pow(sc, 0.3)) * S.cents(r, 8),
+        gain: FREQUENT * 0.7, partials: GLASS,
+      });
+      return 0.3 * sc + 0.5;
+    },
+
+    // A chained cascade step. Same fracture, but the LADDER is the message:
+    // the glass ring climbs a semitone per chain level and the shards brighten
+    // and thicken with it, so a deep cascade is heard going up a staircase.
+    // p.depth = chain level (1, 2, 3, …).
+    'combo': function (ctx, o, t, p, r) {
+      const depth = Math.max(1, ((p && p.depth) | 0) || 1);
+      const step = Math.min(depth, 12);
+      const lift = Math.pow(2, step / 12);
+      S.shatter(ctx, o, t, {
+        dur: 0.26, grains: 24 + step * 2,
+        f0: 3000 * Math.sqrt(lift),
+        skew: 2.0, crack: 0.6, hp: 1800,
+        gain: FREQUENT * (0.85 + 0.05 * step),
+        seed: (r() * 1e6) | 0,
+      });
+      S.body(ctx, o, t + 0.004, {
+        f0: 620 * lift * S.cents(r, 6),
+        gain: FREQUENT * 0.75, partials: GLASS,
+      });
+      return 0.9;
+    },
+
+    // Starflower forming — six tiles collapsing INWARD into chrome. The
+    // reversed shatter (skew < 1, no crack) is the whole idea: the same
+    // granular cloud that means "breaking" everywhere else, run as a
+    // crescendo that converges on the ring of the formed piece. Formation,
+    // not destruction.
+    'starflower': function (ctx, o, t, p, r) {
+      S.shatter(ctx, o, t, {
+        dur: 0.5, grains: 40, f0: 4200,
+        skew: 0.6, crack: 0, hp: 2400, ring: 0.9,
+        gain: 0.10, seed: (r() * 1e6) | 0,
+      });
+      S.strike(ctx, o, t + 0.42, { dur: 0.006, hp: 3200, gain: 0.10, seed: (r() * 1e6) | 0 });
+      S.body(ctx, o, t + 0.42, { f0: S.between(r, 1180, 1300), gain: 0.20, partials: CHROME });
+      return 2.0;
+    },
+
+    // Black pearl forming — the same convergence, but everything is DOWN:
+    // darker shards, and the arrival is not a ring but a weight — a sub thump
+    // under a long obsidian tone. The pair are deliberately opposite ends of
+    // one gesture: starflower ascends into shimmer, pearl descends into mass.
+    'blackpearl': function (ctx, o, t, p, r) {
+      S.shatter(ctx, o, t, {
+        dur: 0.4, grains: 26, f0: 2400,
+        skew: 0.7, crack: 0, hp: 1400, ring: 1.4,
+        gain: 0.06, seed: (r() * 1e6) | 0,
+      });
+      S.thump(ctx, o, t + 0.30, { f0: 72, f1: 34, dur: 0.7, gain: 0.16, attack: 0.02, seed: (r() * 1e6) | 0 });
+      S.body(ctx, o, t + 0.32, { f0: S.between(r, 155, 175), gain: 0.22, partials: OBSIDIAN });
+      return 2.8;
+    },
+
+    // Grand poobah — the rarest formation: both materials at once. A long
+    // double convergence lands on obsidian AND chrome together (the low body
+    // first, the shimmer a beat later, like a bell and its glint), over a
+    // short drone swell that gives the moment a floor.
+    'grandpoobah': function (ctx, o, t, p, r) {
+      const collect = [];
+      S.shatter(ctx, o, t, {
+        dur: 0.7, grains: 60, f0: 3000,
+        skew: 0.55, crack: 0, hp: 1600,
+        gain: 0.09, seed: (r() * 1e6) | 0,
+      });
+      S.drone(ctx, o, t, 2.8, {
+        f: 65, detune: 10, lp: 420, gain: 0.09, fade: 0.9,
+        drift: 0.15, driftAmt: 90, collect,
+      });
+      S.thump(ctx, o, t + 0.55, { f0: 80, f1: 36, dur: 0.8, gain: 0.18, attack: 0.02, seed: (r() * 1e6) | 0 });
+      S.body(ctx, o, t + 0.56, { f0: S.between(r, 125, 140), gain: 0.24, partials: OBSIDIAN });
+      S.body(ctx, o, t + 0.68, { f0: S.between(r, 1500, 1650), gain: 0.14, partials: CHROME });
+      return 3.6;
+    },
+
+    // A bomb LANDS on the board. Three things in order: the impact (it
+    // arrives with weight — the glass around it complains), the fuse catching
+    // (a flare, no crack: ignition, not impact), and then the dread — a low
+    // detuned pair beating at ~3 Hz, unsettling before you can say why.
+    'bomb-arrive': function (ctx, o, t, p, r) {
+      S.thump(ctx, o, t, { f0: S.between(r, 110, 130), f1: 38, dur: 0.5, gain: 0.30, attack: 0.004, seed: (r() * 1e6) | 0 });
+      S.body(ctx, o, t + 0.01, { f0: S.between(r, 280, 320), gain: 0.10, partials: GLASS });
+      S.flare(ctx, o, t + 0.12, {
+        f0: 1600, f1: 900, dur: 0.5, gain: 0.07,
+        weight: 0.15, attack: 0.05, seed: (r() * 1e6) | 0,
+      });
+      // ~3 Hz beat at 92 Hz needs ~55 cents of detune — wide, and meant to be
+      S.body(ctx, o, t + 0.15, {
+        f0: 92, gain: 0.14,
+        partials: [{ ratio: 1.0, gain: 1.0, decay: 1.5, detune: 28, attack: 0.06 }],
+      });
+      return 2.3;
+    },
+
+    // The fuse clock — one tick per move while a bomb is on the board.
+    // p.urgency 0..1 (how close the nearest bomb is to zero): the tick
+    // tightens, sharpens and gains weight as it rises. At 0 it is a dry
+    // mechanism; at 1 it is a hammer on the room.
+    'bomb-tick': function (ctx, o, t, p, r) {
+      const u = clamp01(p && p.urgency);
+      S.strike(ctx, o, t, {
+        dur: 0.004, hp: 1800 + 1400 * u,
+        gain: 0.10 + 0.08 * u, seed: (r() * 1e6) | 0,
+      });
+      S.body(ctx, o, t, {
+        f0: (340 + 160 * u) * S.cents(r, 10), gain: 0.10 + 0.07 * u,
+        partials: [
+          { ratio: 1.0, gain: 1.0, decay: 0.05, detune: 6 },
+          { ratio: 2.76, gain: 0.3, decay: 0.03, detune: 10 },
+        ],
+      });
+      S.thump(ctx, o, t + 0.005, {
+        f0: 88 + 30 * u, f1: 40, dur: 0.16 + 0.05 * u,
+        gain: 0.09 + 0.09 * u, attack: 0.003, seed: (r() * 1e6) | 0,
+      });
+      return 0.5;
+    },
+
+    // The bomb goes. A detonation, not a fireball — full crack — with the
+    // board itself as the resonating container (`tone`): a bell of glass
+    // struck by the blast. Behind the front, the whole board's glass blows
+    // outward in two waves: the near shards immediately, the late fragments
+    // raining down after.
+    'bomb-explode': function (ctx, o, t, p, r) {
+      S.blast(ctx, o, t, {
+        size: S.between(r, 1.15, 1.3), gain: 0.26,
+        crack: 1, tone: 0.5, bf0: 96,
+        f0: 2900, f1: 180, wf0: 120,
+        seed: (r() * 1e6) | 0,
+      });
+      S.shatter(ctx, o, t + 0.03, {
+        dur: 0.9, grains: 90, f0: 2600,
+        skew: 1.6, crack: 0, hp: 1200,
+        gain: 0.16, seed: (r() * 1e6) | 0,
+      });
+      S.shatter(ctx, o, t + 0.25, {
+        dur: 1.1, grains: 40, f0: 1800,
+        skew: 1.2, crack: 0, hp: 900, ring: 1.6,
+        gain: 0.08, seed: (r() * 1e6) | 0,
+      });
+      return 3.6;
+    },
+
+    // The aftermath — three falling obsidian tolls and a last low breath.
+    // Played alone for a chill-session end; after 'bomb-explode' for a real
+    // game over (the wiring staggers them ~0.8s apart).
+    'game-over': function (ctx, o, t, p, r) {
+      const notes = [392, 311, 233];
+      let at = t;
+      for (const f of notes) {
+        S.strike(ctx, o, at, { dur: 0.005, hp: 2000, gain: 0.07, seed: (r() * 1e6) | 0 });
+        S.body(ctx, o, at, { f0: f * S.cents(r, 8), gain: 0.20, partials: OBSIDIAN });
+        at += 0.55;
+      }
+      S.thump(ctx, o, at - 0.3, { f0: 60, f1: 28, dur: 1.2, gain: 0.16, attack: 0.05, seed: (r() * 1e6) | 0 });
+      return 4.5;
+    },
+
+    // Over-achiever — the game's actual triumph condition, and the biggest
+    // cue in the pack: a chrome staircase, a convergence, then the full chord
+    // — obsidian floor, chrome crown, and a swell under it. Bright where
+    // game-over is dark, ascending where it falls.
+    'over-achiever': function (ctx, o, t, p, r) {
+      const collect = [];
+      const steps = [523.25, 659.26, 783.99, 1046.5];
+      steps.forEach((f, i) => {
+        S.strike(ctx, o, t + i * 0.16, { dur: 0.004, hp: 3000, gain: 0.06, seed: (r() * 1e6) | 0 });
+        S.body(ctx, o, t + i * 0.16, { f0: f * S.cents(r, 6), gain: 0.13, partials: GLASS });
+      });
+      S.shatter(ctx, o, t + 0.2, {
+        dur: 0.6, grains: 46, f0: 4000,
+        skew: 0.6, crack: 0, hp: 2400,
+        gain: 0.08, seed: (r() * 1e6) | 0,
+      });
+      S.drone(ctx, o, t, 3.2, {
+        f: 65.4, detune: 7, lp: 460, gain: 0.10, fade: 0.8,
+        drift: 0.12, driftAmt: 110, collect,
+      });
+      const land = t + 0.85;
+      S.thump(ctx, o, land, { f0: 84, f1: 38, dur: 0.9, gain: 0.20, attack: 0.015, seed: (r() * 1e6) | 0 });
+      S.body(ctx, o, land, { f0: 130.8, gain: 0.24, partials: OBSIDIAN });
+      S.body(ctx, o, land + 0.1, { f0: 1046.5 * S.cents(r, 5), gain: 0.16, partials: CHROME });
+      return 6.0;
+    },
+
+    // Puzzle solved — a small warm resolution: a rising glass triad landing
+    // on one chrome note. Deliberately modest next to over-achiever; you may
+    // solve forty of these in a sitting.
+    'game-win': function (ctx, o, t, p, r) {
+      const notes = [523.25, 659.26, 783.99];
+      notes.forEach((f, i) => {
+        S.strike(ctx, o, t + i * 0.12, { dur: 0.004, hp: 2800, gain: 0.06, seed: (r() * 1e6) | 0 });
+        S.body(ctx, o, t + i * 0.12, { f0: f * S.cents(r, 6), gain: 0.15, partials: GLASS });
+      });
+      S.body(ctx, o, t + 0.5, { f0: 1046.5 * S.cents(r, 5), gain: 0.17, partials: CHROME });
+      return 3.0;
+    },
+
+    // Menu / button tink — the quietest cue in the pack, nearly dry.
+    'ui-click': function (ctx, o, t, p, r) {
+      S.strike(ctx, o, t, { dur: 0.003, hp: 3200, gain: 0.10, seed: (r() * 1e6) | 0 });
+      S.body(ctx, o, t, {
+        f0: S.between(r, 1700, 1900), gain: 0.09,
+        partials: [
+          { ratio: 1.0, gain: 1.0, decay: 0.04, detune: 4 },
+          { ratio: 2.32, gain: 0.2, decay: 0.02, detune: 7 },
+        ],
+      });
+      return 0.1;
+    },
+  };
+
+  // ── the beds ──────────────────────────────────────────────────────────────
+  // Sustained cues in the SDK's shape: fn(ctx, out, when, params, rnd)
+  // returning a teardown. Two layers on different clocks, so the tension can
+  // be retuned (handle.retune) without restarting the pulse under it.
+
+  // The room's heartbeat. NOT metrical: a puzzle game with no move clock has
+  // no tempo to sync to, and a steady BPM fights the player's own pacing. So
+  // it breathes instead — a low lub, usually answered by a softer dub, at a
+  // spacing that wanders. `params.intensity` 0..1 (set per mode: chill low,
+  // arcade higher) draws the beats closer and the answer more certain.
+  function pulse(ctx, o, t, params, r) {
+    const dur = (params && params.dur) || 420;
+    const it = clamp01(params && params.intensity);
+    const collect = [];
+    S.drone(ctx, o, t, dur, {
+      f: 41.2, detune: 5, lp: 260, gain: 0.020 + 0.015 * it,
+      fade: 2.5, drift: 0.05, driftAmt: 70, collect,
+    });
+    let at = t + S.between(r, 0.8, 1.6);
+    while (at < t + dur - 1.0) {
+      const g = (0.035 + 0.030 * it) * S.between(r, 0.8, 1.1);
+      S.thump(ctx, o, at, {
+        f0: S.between(r, 54, 62), f1: 30, dur: 0.32, gain: g,
+        attack: 0.012, seed: (r() * 1e6) | 0, collect,
+      });
+      if (r() < 0.5 + 0.4 * it) {
+        S.thump(ctx, o, at + S.between(r, 0.30, 0.38), {
+          f0: 48, f1: 27, dur: 0.26, gain: g * 0.55,
+          attack: 0.014, seed: (r() * 1e6) | 0, collect,
+        });
+      }
+      at += S.between(r, 1.7, 2.6) / (1 + 0.8 * it);
+    }
+    return S.teardown(collect);
+  }
+
+  // The bomb layer. `params.urgency` 0..1 tracks the nearest fuse: a beating
+  // drone whose beat rate rises with urgency, and a dry tick subdividing the
+  // pulse faster and harder as the fuse shortens. At 0 it schedules nothing —
+  // no bombs, no tension, and the pulse alone is the whole floor.
+  function tension(ctx, o, t, params, r) {
+    const dur = (params && params.dur) || 420;
+    const u = clamp01(params && params.urgency);
+    const collect = [];
+    if (u <= 0) return S.teardown(collect);
+    S.drone(ctx, o, t, dur, {
+      f: 82.4, detune: 18 + 26 * u, lp: 500,
+      gain: 0.012 + 0.020 * u, fade: 1.2,
+      drift: 0.09, driftAmt: 120, collect,
+    });
+    const step = 0.9 / (1 + 1.6 * u);
+    let at = t + 0.5;
+    while (at < t + dur - 0.5) {
+      S.strike(ctx, o, at, {
+        dur: 0.004, hp: S.between(r, 2400, 2900),
+        gain: 0.020 + 0.030 * u, seed: (r() * 1e6) | 0, collect,
+      });
+      at += step * S.between(r, 0.92, 1.08);
+    }
+    return S.teardown(collect);
+  }
+
+  global.HecknsicPack = {
+    name: 'hecknsic', ROOM, SENDS, CUES,
+    GLASS, CHROME, OBSIDIAN,
+    pulse, tension,
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.4.1';
+const APP_VERSION = '1.4.2';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.4.2';
+const APP_VERSION = '1.5.0';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets
@@ -24,6 +24,7 @@ const STATIC_ASSETS = [
   './js/puzzles.js',
   './js/renderer.js',
   './js/score.js',
+  './js/soundpack.js',
   './js/specials.js',
   './js/storage.js',
   './js/tween.js',

--- a/tests/audio.test.js
+++ b/tests/audio.test.js
@@ -1,0 +1,156 @@
+/**
+ * audio.test.js — which registration path js/audio.js takes, and that no
+ * play-wrapper can throw on any of them.
+ *
+ * The path choice is the whole safety story of this module. A player on a
+ * stale service-worker cache gets an older /arcade-audio.js that still has
+ * `graph()` and `el()` but is missing the elements the pack is built from —
+ * and a cue that half-plays and then throws at play time is worse than the
+ * archived chiptune profile. So the graph path is gated on the pack's actual
+ * element dependencies, not on a version number, and that gate is what these
+ * tests pin down.
+ *
+ * Every case also asserts the graph-only wrappers are safe no-ops on the
+ * fallback path: they are called from the game loop, the input path and the
+ * move path, where a throw would take the game down with it.
+ */
+
+import assert from 'node:assert';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const AUDIO = join(dirname(fileURLToPath(import.meta.url)), '..', 'js', 'audio.js');
+
+// The full element library as of the version this pack was written against.
+const ALL_ELEMENTS = [
+  'strike', 'rustle', 'pluck', 'creak', 'droplet', 'body', 'thump', 'flare',
+  'blast', 'chirp', 'stream', 'shatter', 'ratchet', 'drone', 'teardown',
+];
+
+// What this game's pack actually needs beyond the pre-3.7.0 set.
+const NEW_ELEMENTS = ['shatter', 'ratchet', 'drone'];
+
+const PACK_CUES = [
+  'rotate', 'select', 'match', 'combo', 'starflower', 'blackpearl',
+  'grandpoobah', 'bomb-arrive', 'bomb-tick', 'bomb-explode', 'game-over',
+  'over-achiever', 'game-win', 'ui-click',
+];
+
+/** A stub `window` with a recording Arcade.audio surface. */
+function makeWindow({ elements, withPack }) {
+  const seen = { cues: [], graphs: [], rooms: 0 };
+  const el = Object.fromEntries(elements.map((n) => [n, () => {}]));
+  const audio = {
+    cue(n) { seen.cues.push(n); return audio; },
+    graph(n, fn, o) { seen.graphs.push({ n, sustained: !!(o && o.sustained) }); return audio; },
+    room() { seen.rooms++; return audio; },
+    start() { return { stop() {}, retune() {} }; },
+    play() {},
+    el: () => el,
+  };
+  const w = { Arcade: { audio } };
+  if (withPack) {
+    w.HecknsicPack = {
+      ROOM: {}, SENDS: {},
+      CUES: Object.fromEntries(PACK_CUES.map((n) => [n, () => {}])),
+      pulse() {}, tension() {},
+    };
+  }
+  return { w, seen };
+}
+
+// Each import needs a distinct query so the module re-evaluates: registration
+// is a load-time side effect (convention A1), which is the thing under test.
+async function loadAudio(w, tag) {
+  global.window = w;
+  return import(`${AUDIO}?${tag}`);
+}
+
+/** Every wrapper the game calls, with representative arguments. */
+function callEveryWrapper(m) {
+  m.playRotate('cluster'); m.playRotate('ring'); m.playRotate('y'); m.playRotate();
+  m.playSelect();
+  m.playMatch(3); m.playMatch(12);
+  m.playCombo(1); m.playCombo(20);
+  m.playSpecial('starflower'); m.playSpecial('blackpearl'); m.playSpecial('grandpoobah');
+  m.playSpecial('nonsense');
+  m.playBombArrive();
+  m.playBombTick(0); m.playBombTick(1);
+  m.playGameOver(false); m.playGameOver(true);
+  m.playOverAchiever(); m.playGameWin();
+  m.startBed('arcade'); m.startBed('chill'); m.startBed('puzzle'); m.startBed(undefined);
+  m.setBedUrgency(0); m.setBedUrgency(0.9); m.setBedUrgency(NaN); m.setBedUrgency();
+  m.stopBed(); m.stopBed(2);
+}
+
+test('graph path: modern element library + pack present', async () => {
+  const { w, seen } = makeWindow({ elements: ALL_ELEMENTS, withPack: true });
+  const m = await loadAudio(w, 'graph');
+
+  assert.equal(seen.rooms, 1, 'the shared room is installed exactly once');
+  assert.equal(seen.cues.length, 0, 'no chiptune cues registered on the graph path');
+  assert.equal(seen.graphs.length, PACK_CUES.length + 2, 'every pack cue plus both beds');
+  assert.deepEqual(
+    seen.graphs.filter((g) => g.sustained).map((g) => g.n).sort(),
+    ['pulse', 'tension'],
+    'the beds — and only the beds — register as sustained',
+  );
+  assert.doesNotThrow(() => callEveryWrapper(m));
+});
+
+// The case this gate exists for: `graph()` and `el()` are present, so a naive
+// version check would take the graph path and then throw inside a cue.
+for (const missing of NEW_ELEMENTS) {
+  test(`fallback: element library missing '${missing}'`, async () => {
+    const { w, seen } = makeWindow({
+      elements: ALL_ELEMENTS.filter((n) => n !== missing),
+      withPack: true,
+    });
+    const m = await loadAudio(w, `missing-${missing}`);
+
+    assert.equal(seen.graphs.length, 0, 'must not take the graph path');
+    assert.equal(seen.rooms, 0, 'must not install a room it cannot use');
+    assert.ok(seen.cues.includes('match'), 'archived chiptune profile registered instead');
+    assert.doesNotThrow(() => callEveryWrapper(m));
+  });
+}
+
+test('fallback: the archived chiptune profile registers its full cue set', async () => {
+  const stale = ALL_ELEMENTS.filter((n) => !NEW_ELEMENTS.includes(n));
+  const { w, seen } = makeWindow({ elements: stale, withPack: true });
+  await loadAudio(w, 'stale-all');
+
+  assert.deepEqual(
+    seen.cues.slice().sort(),
+    ['bomb', 'combo', 'game-over', 'match', 'rotate', 'special', 'ui-click'],
+    'exactly the cues frozen at 9169f43',
+  );
+});
+
+test('fallback: pack script absent (standalone, no soundpack.js)', async () => {
+  const { w, seen } = makeWindow({ elements: ALL_ELEMENTS, withPack: false });
+  const m = await loadAudio(w, 'nopack');
+
+  assert.equal(seen.graphs.length, 0, 'no pack means no graph path');
+  assert.ok(seen.cues.includes('match'), 'chiptune registered');
+  assert.doesNotThrow(() => callEveryWrapper(m));
+});
+
+test('no Arcade at all: import is inert and every wrapper is a safe no-op', async () => {
+  global.window = {};
+  const m = await loadAudio(global.window, 'noarcade');
+  assert.doesNotThrow(() => callEveryWrapper(m));
+});
+
+test('comboFreq: rises with depth and stays inside a sane range', async () => {
+  const { w } = makeWindow({ elements: ALL_ELEMENTS, withPack: true });
+  const { comboFreq } = await loadAudio(w, 'combofreq');
+
+  assert.equal(comboFreq(0), 440, 'base note at depth 0');
+  assert.ok(comboFreq(3) > comboFreq(1), 'monotonic in depth');
+  assert.equal(comboFreq(12), 880, 'twelve semitones is exactly an octave');
+  // capped at 15 semitones so a runaway cascade cannot walk out of the band
+  assert.equal(comboFreq(15), comboFreq(99), 'clamped above 15 semitones');
+  assert.equal(comboFreq(-5), 440, 'negative depth clamps to the base note');
+});


### PR DESCRIPTION
Audio overhaul for hecknsic, in the same shape as moon-lit's (#25/#28): physical-gesture synthesis on the launcher's shared element library, a game-owned sound pack, and an offline-rendered audition approved by ear.

**Depends on** paulgibeault/paulgibeault.github.io#97 — **SDK 3.8.0**, which ships the `shatter` / `ratchet` / `drone` elements. Until that deploys, this branch cleanly falls back to the archived chiptune profile rather than breaking, and `tests/audio.test.js` pins that behaviour.

**Supersedes #45** — that draft's chiptune tuning is preserved verbatim here as the fallback path, so it does not need to land separately.

## ⚠️ Not yet ear-passed

The pack was written against audition v1 and **has not had its listening pass**. That is the point of the workflow — retuning happens against a re-render, not against the wired game:

```bash
cd ../paulgibeault.github.io && node tools/soundpack/render.mjs hecknsic
```

Quote a timestamp from the generated `INDEX.md` and the cue can be fixed without re-auditioning the rest.

## The design

A dark room with a glass machine in it. Three decisions carry it:

**Tiles are glass.** Every clear is a granular `shatter` scaled by how much broke — a 10-tile match is a *bigger fracture*, not a louder one — and every formed piece rings, using per-material partial tables (`GLASS`, `CHROME` for the starflower's silver, `OBSIDIAN` for the black pearl).

**Formation is that same shatter run backwards.** `skew < 1` turns the shard cloud into a converging crescendo: glass assembling instead of breaking. So the three specials are one gesture in three materials — starflower ascends into shimmer, black pearl descends into mass, grand poobah lands both at once. They were previously one shared `special` cue.

**Rotation ratchets.** The only mechanical act in the game, so it gets machined detents rather than glass — decelerating like a hand settling a dial, sized to what is actually turning (3 cluster / 4 pearl-Y / 6 starflower ring), ending on the knock of the cluster seating. It fires on every input, so it lives at the mix's `CONSTANT` anchor with heavy per-play variation: a mechanism that makes the same noise every turn stops being furniture and becomes a beep.

**The bomb becomes an event chain** rather than a single queue blip — arrival (impact + fuse catching + a beating dread pair), a tick per move whose `urgency` tightens it as the fuse burns down, then a real detonation with the board ringing as its container and its glass blowing outward in two waves, with the aftermath tolls a beat behind.

**The floor breathes.** Two sustained beds: a non-metrical sub heartbeat whose intensity follows the mode, and a tension layer tracking the shortest live fuse that schedules *nothing* when the board is clear. Deliberately not on a tempo — a puzzle game with no move clock has no beat for the player's own pacing to fight. (If the ear pass wants it metrical, that changes only `pulse()` in the pack.)

## Five events that were silent now have sound

Cluster pickup · the bomb tick · the detonation itself · the puzzle win · and the **over-achiever**, which is the game's actual triumph condition and had no cue at all.

## Two unrelated bugs found while verifying

- **`ago` was badly out of date.** It staged a hardcoded list of launcher files that had fallen behind the SDK — 17 companion modules plus `catalog.json` 404'd and the launcher came up broken. It now globs `arcade-*.js`, so it tracks the SDK automatically instead of needing a manual edit per new module.
- **`.arcade-stage/`** — ago's dev output — was never gitignored.

## Verification

- Graph path confirmed **live in the browser**, not silently falling back: the shared room bus exists (only `room()` creates it) and `start('pulse')` returns a handle carrying `retune`.
- All 19 cue invocations the game can emit play without throwing, at both parameter extremes.
- Adaptive retune steps 0 → 0.35 → 0.7 → 1.0 cleanly on a live bed.
- `tests/audio.test.js` pins the registration-path contract — including the case the element gate exists for: a cached library that still has `graph()` and `el()` but is missing any one of `shatter`/`ratchet`/`drone` must fall back rather than throw inside a cue at play time.
- **74 tests pass** (66 existing + 8 new).

Full design and wiring notes in `docs/audio-overhaul.md`.
