### PR TITLE
fix: bump SW cache version so the resize fix reaches returning players

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Hecknsic Service Worker — offline-first cache
-const APP_VERSION = '1.5.1';
+const APP_VERSION = '1.5.2';
 const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
 
 // WARNING: This list is manually maintained. When adding new static assets


### PR DESCRIPTION
#51 landed on the origin but **is not reaching returning players.**

## Why

`sw.js` is cache-first for everything in scope in production, keyed on:

```js
const APP_VERSION = '1.5.1';
const CACHE_VERSION = `hecknsic-v${APP_VERSION}`;
```

`APP_VERSION` is hardcoded, and the fleet auto-bump never touches it — [fleet-ci.yml](https://github.com/paulgibeault/paulgibeault.github.io/blob/main/.github/workflows/fleet-ci.yml) rewrites `package.json`, `manifest.json` and `index.html` only. So after #51 merged, `sw.js` was byte-identical → no SW update → no `install` → activate-time cleanup never ran → the `hecknsic-v1.5.1` cache kept serving the **pre-fix** `js/renderer.js`.

Confirmed on production after the deploy went green:

```
cacheKeys:             ["pi-game-v7", "paul-arcade-v67", "hecknsic-v1.5.1"]
controlled:            true
cachedRendererHasFix:  false     ← what a returning player executes
networkRendererHasFix: true      ← what the origin serves
```

## The fix

`APP_VERSION` `1.5.1` → `1.5.2`. That changes `sw.js`'s bytes, which is the thing that triggers install → activate → drop every cache key that isn't current.

## Two notes

- `./index.html` is in `STATIC_ASSETS`, so a returning player's **version badge is stale too**. The badge can't be used to confirm a deploy landed for this game — check the origin directly.
- App version (`1.2.26`) and SW version (`1.5.x`) are unrelated numbering schemes, so the drift isn't visually obvious.

The launcher already has a CI gate for exactly this (`tools/check-sw-bump.mjs`, which fails when a precached asset changes without a cache-name bump). This repo has no equivalent, which is why #51 merged green while shipping stale. Porting that gate is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)