### PR TITLE
Generated SW precache (fixes live offline bug); Arcade.loop (fixes double-speed bug)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -106,7 +106,6 @@ let selectedCluster = null;
 let flowerCenter = null;     // {col,row} if a starflower ring is selected
 let pearlCenter = null;      // {col,row} if a black pearl Y-shape is selected
 let lastTime = 0;
-let rafId = null;
 let moveCount = 0;           // total player moves (for bomb spawn timing)
 let bombQueued = false;
 let boardGeneration = 0;  // incremented on grid replacement; stale async chains bail out
@@ -134,13 +133,13 @@ initInput(canvas);
 // dt doesn't jump after a long suspension.
 if (typeof window !== 'undefined' && window.Arcade) {
   Arcade.onSuspend(() => {
+    // Arcade.loop parks itself on suspend; this only records intent.
     isPaused = true;
-    if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
   });
   Arcade.onResume(() => {
     isPaused = false;
     lastTime = performance.now();
-    rafId = requestAnimationFrame(gameLoop);
+    gameFrameLoop.start();
   });
 
   // After the launcher imports a save, every persisted key the game reads at
@@ -607,15 +606,20 @@ if (savedState) {
   state = 'idle';
 }
 
-rafId = requestAnimationFrame(gameLoop);
+// The SDK owns the frame loop. Arcade.loop cancels on suspend and re-arms on
+// resume, and start() is idempotent — it can never stack a second concurrent
+// loop, which is what the restart path used to do.
+const gameFrameLoop = Arcade.loop(gameLoop);
+gameFrameLoop.start();
 
 // ─── Game loop ──────────────────────────────────────────────────
 
-function gameLoop(timestamp) {
-  if (isPaused) {
-    rafId = requestAnimationFrame(gameLoop);
-    return;
-  }
+// Arcade.loop passes (deltaMs, timestamp); the local dt is kept because it
+// carries this game's own 16 ms first-frame default.
+function gameLoop(_deltaMs, timestamp) {
+  // Paused means paused: park the loop rather than burning a frame slot each
+  // tick to do nothing. onResume/restart start() it again.
+  if (isPaused) { gameFrameLoop.stop(); return; }
 
   const dt = lastTime ? timestamp - lastTime : 16;
   lastTime = timestamp;
@@ -633,7 +637,6 @@ function gameLoop(timestamp) {
     // drawGameOver(); // Handled by DOM overlay now
     
     updateGameHUD();
-    rafId = requestAnimationFrame(gameLoop);
     return;
   }
 
@@ -685,8 +688,6 @@ function gameLoop(timestamp) {
 
   updateControlsVisibility();
   updateGameHUD();
-
-  rafId = requestAnimationFrame(gameLoop);
 }
 
 /**
@@ -1118,7 +1119,11 @@ function resetGame() {
   // Ensure we are unpaused and running
   isPaused = false;
   lastTime = performance.now();
-  rafId = requestAnimationFrame(gameLoop); // Might already be running, but safe to ensure
+  // This line used to read "might already be running, but safe to ensure" and
+  // raw requestAnimationFrame made that false: restarting a live game stacked
+  // a second loop and orphaned the first, so tweens ran at 2x and the board
+  // drew twice per frame, permanently. loop.start() is genuinely idempotent.
+  gameFrameLoop.start();
 }
 
 function saveGame() {

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
  *
  * CANONICAL FLEET SHAPE. The structure here — version line, owned-prefix
  * cleanup, cache-first fetch, skip-waiting message — is meant to be identical
- * across every arcade app; only APP_VERSION, CACHE_PREFIX and PRECACHE differ.
+ * across every arcade app; only APP_VERSION, CACHE_PREFIX and ASSETS differ.
  * Fix a bug here and it has to be carried everywhere, the same rule as
  * tools/verify-artifact.mjs.
  */
@@ -26,37 +26,30 @@ const CACHE_VERSION = `${CACHE_PREFIX}v${APP_VERSION}`;
 // WARNING: This list is manually maintained. When adding new static assets
 // (JS files, CSS files, images, sounds, etc.), update this list too or
 // offline mode will silently break for those assets.
-const PRECACHE = [
+// Everything this game needs to boot offline — GENERATED, not maintained.
+// tools/stage.mjs rewrites the region below from the files the deploy actually
+// publishes (tools/inject-precache.mjs), so the list cannot drift from the
+// artifact and a content-hashed bundle name needs no hand edit. To leave a
+// file out, name it in PRECACHE_EXCLUDE in tools/stage.mjs — never here.
+//
+// What is checked in is a placeholder: service workers are off on loopback, so
+// a dev checkout never reads it.
+// arcade:precache-begin
+const ASSETS = [
   './',
   './index.html',
-  './manifest.json',
-  './css/style.css',
-  './css/overlays.css',
-  './js/audio.js',
-  './js/board.js',
-  './js/constants.js',
-  './js/daily-puzzle.js',
-  './js/hex-math.js',
-  './js/input.js',
-  './js/main.js',
-  './js/modes.js',
-  './js/puzzle-editor.js',
-  './js/puzzle-mode.js',
-  './js/puzzles.js',
-  './js/renderer.js',
-  './js/score.js',
-  './js/soundpack.js',
-  './js/specials.js',
-  './js/storage.js',
-  './js/tween.js',
-  './img/logo_header.png',
-  './img/icon-192.png',
-  './img/icon-512.png',
 ];
+// arcade:precache-end
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_VERSION).then((cache) => cache.addAll(PRECACHE))
+    caches.open(CACHE_VERSION).then(cache => Promise.all(
+      // Per-asset add(), not addAll(). addAll() rejects the WHOLE install on a
+      // single 404, so one missing file costs a returning player their entire
+      // offline shell — silently. A gap should cost one file and a log line.
+      ASSETS.map(asset => cache.add(asset).catch(err =>
+        console.warn('[sw] precache skipped', asset, err && err.message)))
+    ))
   );
   // Deliberately NOT skipWaiting(). The new worker installs and waits; the
   // launcher spots it and offers the player an explicit "update ready" reload,
@@ -120,7 +113,7 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(event.request).then((cached) => {
+    caches.match(event.request, { ignoreSearch: true }).then((cached) => {
       if (cached) return cached;
       return fetch(event.request).then((response) => {
         if (!response || response.status !== 200 || response.type === 'opaque') {

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -35,16 +35,21 @@ const SW_SRC = readFileSync(join(ROOT, 'sw.js'), 'utf8');
 const PKG = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')); // used for realistic cache keys
 
 /** Evaluate sw.js against a fake global scope and return the handles. */
-function loadWorker({ cacheKeys = [] } = {}) {
+function loadWorker({ cacheKeys = [], failAdd = null } = {}) {
   const deleted = [];
   const handlers = {};
-  const calls = { skipWaiting: 0, claim: 0, addAll: null };
+  const calls = { skipWaiting: 0, claim: 0, added: [] };
 
   const caches = {
     keys: async () => cacheKeys.slice(),
     delete: async (k) => { deleted.push(k); return true; },
     open: async () => ({
-      addAll: async (list) => { calls.addAll = list; },
+      // Per-asset add(), matching the shared template. `failAdd` makes one
+      // entry 404 so a test can prove the rest still cache.
+      add: async (asset) => {
+        if (asset === failAdd) throw new Error('404');
+        calls.added.push(asset);
+      },
       put: async () => {},
     }),
     match: async () => undefined,
@@ -132,15 +137,29 @@ test('install precaches and does NOT skipWaiting', async () => {
   const w = loadWorker();
   await w.fire('install');
 
-  assert.ok(w.calls.addAll && w.calls.addAll.length > 0, 'install should precache assets');
-  assert.ok(
-    w.calls.addAll.includes('./index.html') && w.calls.addAll.includes('./js/renderer.js'),
-    'the precache list should cover the app shell and its JS');
+  assert.ok(w.calls.added.length > 0, 'install should precache assets');
+  // Only the shell is asserted here. WHAT gets precached is no longer written
+  // in this file — tools/stage.mjs generates the list from the deploy artifact,
+  // so the checked-in array is a placeholder and this test would be asserting
+  // a fixture. Coverage of the real list lives in tools/verify-artifact.mjs,
+  // which fails on any published file the worker does not cache.
+  assert.ok(w.calls.added.includes('./index.html'),
+    'the app shell should always be precached');
   assert.strictEqual(
     w.calls.skipWaiting, 0,
     'install must not skipWaiting — the launcher\'s update prompt depends on ' +
     'the new worker waiting, and activating unannounced swaps the cache under ' +
     'a running game');
+});
+
+test('one missing asset does not cost the player the whole offline shell', async () => {
+  // The reason install() uses per-asset add() rather than addAll(): addAll()
+  // rejects entirely on a single 404, so one unpublished file silently leaves
+  // a returning player with no cache at all. A gap should cost one file.
+  const w = loadWorker({ failAdd: './index.html' });
+  await w.fire('install');
+  assert.ok(w.calls.added.length > 0,
+    'the surviving assets should still be cached when one entry 404s');
 });
 
 test('the launcher can activate a waiting worker on demand', async () => {

--- a/tools/inject-precache.mjs
+++ b/tools/inject-precache.mjs
@@ -1,0 +1,133 @@
+// The service worker's precache list, written from the artifact that actually
+// deploys instead of maintained by hand.
+//
+// IDENTICAL IN EVERY FLEET REPO. Do not edit one copy: change the canonical
+// file and re-copy it (GAME_INTEGRATION §13a). Like verify-artifact.mjs it is
+// a plain module, callable from any of the three test runners the fleet uses.
+//
+// WHY THIS EXISTS
+//
+// A hand-listed precache is three lists that must agree — index.html's tags,
+// sw.js's array, and what the deploy publishes — with nothing checking the
+// third against the second. Every drift mode showed up in the fleet at once:
+// an app shipped a bundled file the list could not name because the name is
+// content-hashed and changes every build; another listed paths in a form the
+// verifier's pattern never matched, so its entries went unchecked for months;
+// a third precached a file it no longer published. The failure is always the
+// same shape and always silent — install() rejects, or the cache is missing
+// the one file the game needs, and the only symptom is a game that works
+// online and breaks on a plane.
+//
+// So the list is generated. The input is the staged directory, which is the
+// bytes that deploy; nothing can be listed that isn't published, and nothing
+// published is omitted unless the app says so out loud.
+//
+// THE CONTRACT
+//
+// sw.js carries a generated region, and this rewrites what is between the
+// markers:
+//
+//   // arcade:precache-begin
+//   const ASSETS = [ './', './index.html' ];
+//   // arcade:precache-end
+//
+// The checked-in list is a placeholder — service workers are disabled on
+// loopback fleet-wide, so a dev checkout never uses it.
+//
+// An app that must leave something out of the cache — a diagnostic it ships
+// but never boots, a heavy asset it fetches on demand — declares it as
+// PRECACHE_EXCLUDE in tools/stage.mjs, where the rest of its per-app deploy
+// declaration already lives. That is deliberately the only knob, and it is
+// visible in review: verify-artifact.mjs asserts that every published file is
+// either precached or named there, so dropping a file out of the cache is a
+// decision someone writes down rather than an omission nobody notices.
+import fs from "node:fs";
+import path from "node:path";
+
+const BEGIN = "// arcade:precache-begin";
+const END = "// arcade:precache-end";
+
+/** Every file in the artifact, as forward-slash paths relative to its root. */
+export function artifactFiles(dir) {
+  const walk = (d) => fs.readdirSync(d, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(d, e.name);
+    return e.isDirectory() ? walk(p) : [path.relative(dir, p).split(path.sep).join("/")];
+  });
+  return walk(dir).sort();
+}
+
+/**
+ * Files that are published but never precached, whatever the app.
+ *
+ * sw.js itself: the worker is fetched by the browser's update check, which
+ * must reach the network to ever see a new version — caching it is how a
+ * worker makes itself permanent.
+ *
+ * Dotfiles: .DS_Store, .gitkeep and friends are never runtime assets. They
+ * should not be in the artifact at all, but a precache list is the wrong
+ * place to discover that, and addAll() rejecting on one would take the whole
+ * cache down with it.
+ */
+const NEVER = (rel) => rel === "sw.js" || rel.split("/").some((seg) => seg.startsWith("."));
+
+/**
+ * True if `rel` is excluded by `patterns`.
+ *
+ * Three forms, deliberately not a glob library: an exact path, a `dir/`
+ * prefix, and a `*.ext` suffix. Exclusions are read by whoever reviews a
+ * deploy, so the vocabulary stays small enough to be obvious at a glance —
+ * and anything subtler than "this file", "this directory" or "this kind of
+ * file" is a sign the artifact itself wants fixing, not the filter.
+ */
+export function isExcluded(rel, patterns) {
+  return patterns.some((p) => {
+    if (p.startsWith("*")) return rel.endsWith(p.slice(1));
+    if (p.endsWith("/")) return rel.startsWith(p);
+    return rel === p;
+  });
+}
+
+/** What the artifact in `dir` should precache, given the app's exclusions. */
+export function precacheList(dir, exclude = []) {
+  const entries = artifactFiles(dir)
+    .filter((f) => !NEVER(f) && !isExcluded(f, exclude))
+    .map((f) => `./${f}`);
+  // "./" is the directory itself — what a player actually navigates to. It is
+  // a distinct cache key from ./index.html and both are needed: the former is
+  // the URL, the latter is what a relative fetch resolves to.
+  return ["./", ...entries];
+}
+
+/**
+ * Rewrite the generated region of `dir/sw.js` from the staged artifact.
+ * Returns the entries written, or null if this artifact ships no worker.
+ */
+export function injectPrecache(dir, { exclude = [] } = {}) {
+  const swPath = path.join(dir, "sw.js");
+  if (!fs.existsSync(swPath)) return null;
+
+  const src = fs.readFileSync(swPath, "utf8");
+  const from = src.indexOf(BEGIN);
+  const to = src.indexOf(END);
+  if (from === -1 || to === -1 || to < from) {
+    throw new Error(
+      `sw.js has no generated precache region — expected ${BEGIN} … ${END}. ` +
+      `See tools/templates/game-sw.js (GAME_INTEGRATION §10).`
+    );
+  }
+
+  const entries = precacheList(dir, exclude);
+  const block = [
+    BEGIN,
+    "// Generated at stage time by tools/inject-precache.mjs from the files this",
+    "// deploy actually publishes. DO NOT EDIT BY HAND — your edit is overwritten",
+    "// on the next build. To leave a file out, add it to PRECACHE_EXCLUDE in",
+    "// tools/stage.mjs.",
+    "const ASSETS = [",
+    ...entries.map((e) => `  '${e}',`),
+    "];",
+  ].join("\n");
+
+  fs.writeFileSync(swPath, src.slice(0, from) + block + "\n" + src.slice(to));
+  return entries;
+}

--- a/tools/stage.mjs
+++ b/tools/stage.mjs
@@ -12,8 +12,30 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { injectPrecache } from "./inject-precache.mjs";
 
 export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Published, deliberately not precached. This is the only knob on the
+// generated list (tools/inject-precache.mjs), and it is reviewed rather than
+// silent: tools/verify-artifact.mjs fails the build on any published file that
+// is neither cached nor named here.
+//
+// The audition diagnostic and its config, the frozen chiptune archive kept as
+// provenance, a prose blob nothing fetches, and the licence text.
+//
+// js/animations.js and js/arcade-rng.js are deliberately NOT here: both are
+// imported by the game at runtime and were simply missing from the old
+// hand-kept list, so the daily puzzle broke offline. Generating the list is
+// what surfaced that.
+export const PRECACHE_EXCLUDE = [
+  "audio/audition.js",
+  "audio/chiptune-archive.mjs",
+  "soundpack.config.json",
+  "js/additional-description",
+  "LICENSE",
+];
+
 
 // Dev-only: tooling, tests, notes, and local helpers. Everything else a repo
 // tracks is game content and ships.
@@ -42,6 +64,9 @@ export function stage(outDir) {
     fs.copyFileSync(path.join(ROOT, f), path.join(outDir, f));
     staged++;
   }
+  // Last, so it sees the finished artifact — the precache list is written from
+  // what is actually about to deploy, not from what anyone believes is.
+  injectPrecache(outDir, { exclude: PRECACHE_EXCLUDE });
   return { outDir, staged, total: files.length };
 }
 

--- a/tools/verify-artifact.mjs
+++ b/tools/verify-artifact.mjs
@@ -12,6 +12,7 @@
 //
 //   stage(outDir) -> { outDir }   // produce the deploy artifact in outDir
 //   ROOT                          // repo root
+//   PRECACHE_EXCLUDE              // optional; published but not precached
 //
 // Three lists have to agree and none of them check each other: index.html's
 // tags, the service worker's precache list, and what the deploy publishes.
@@ -19,11 +20,21 @@
 // them — every file is obviously present in a checkout. So stage for real
 // and read what came out.
 //
+// Since stage() generates the precache list from the artifact
+// (tools/inject-precache.mjs), the old direction of that check — "every
+// precached file is published" — can no longer fail; it is now a property of
+// how the list is built. The direction that CAN still fail is the reverse,
+// and it is the one that actually strands players offline: a file the deploy
+// publishes and the worker never caches. That is asserted below, with
+// PRECACHE_EXCLUDE as the app's written-down list of deliberate omissions.
+//
 // Usage: node tools/verify-artifact.mjs [--keep <dir>]
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { stage, ROOT } from "./stage.mjs";
+import { artifactFiles, isExcluded } from "./inject-precache.mjs";
+import * as staging from "./stage.mjs";
+const { stage, ROOT } = staging;
 
 /** Literal local src/href targets — an expression built in JS isn't a filename. */
 function indexRefs(dir) {
@@ -63,6 +74,22 @@ export function verify(dir) {
   for (const entry of sw.entries) {
     // "" is "./" — the directory itself, served as index.html.
     if (!has(entry || "index.html")) bad.push(`sw.js precaches ./${entry}, the deploy drops it`);
+  }
+
+  // The reverse: a published file the worker never caches is a file that is
+  // there online and gone on a plane. Silent by construction — every gate the
+  // fleet had was green while a bundled entry point sat outside the cache —
+  // so the artifact is what gets asked, and the only accepted answer for a
+  // missing file is that the app declared it missing on purpose.
+  if (fs.existsSync(path.join(dir, "sw.js"))) {
+    const cached = new Set(sw.entries.map((e) => e || "index.html"));
+    const exclude = staging.PRECACHE_EXCLUDE || [];
+    for (const f of artifactFiles(dir)) {
+      if (f === "sw.js" || f.split("/").some((s) => s.startsWith("."))) continue;
+      if (cached.has(f) || isExcluded(f, exclude)) continue;
+      bad.push(`the deploy publishes ${f}, sw.js never caches it ` +
+        `(precache it, or name it in PRECACHE_EXCLUDE in tools/stage.mjs)`);
+    }
   }
   // The game↔launcher boundary, checked from whichever side this repo is on.
   // A game loads /arcade-sdk.js and /arcade-audio.js from the launcher origin


### PR DESCRIPTION
Two commits from the fleet alignment pass (paulgibeault/paulgibeault.github.io#39; launcher side in paulgibeault/paulgibeault.github.io#122). Both commits fix a real defect found in flight.

**Generated precache — found a live offline bug.** `js/animations.js` and `js/arcade-rng.js` are imported at runtime (main.js and daily-puzzle.js) but were never in the hand-kept PRECACHE array, so the daily puzzle could not load offline. Every gate was green because every gate checked the other direction. Both are in the generated list now, which `tools/stage.mjs` writes from the staged artifact; `PRECACHE_EXCLUDE` names the deliberate omissions, and `verify-artifact.mjs` fails on any published-but-uncached file. The array also renames PRECACHE→ASSETS to match the shared template. Per-asset `add()` and `ignoreSearch` ride along; the SW test now covers the one-404-does-not-kill-the-shell property and stops asserting a list this repo no longer writes.

**Arcade.loop — fixes a permanent double-speed bug.** The restart path did:

    rafId = requestAnimationFrame(gameLoop); // Might already be running, but safe to ensure

It was not safe: restarting a live game scheduled a second concurrent gameLoop and orphaned the first (onSuspend only knew the newest id), permanently doubling frame rate — tweens at 2x, dt accumulated twice, board drawn twice — for the rest of the session. `loop.start()` is genuinely idempotent, so the same call site is now correct. The loop also parks while paused instead of re-arming every frame to do nothing.

Verification: 82 tests pass; rendered correctly in a real browser against a staged launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)