### PR TITLE
perf: let the screen rest — park the loop when idle, gate decoration on power saver (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Hecknsic is a captivating puzzle game designed for modern web platforms, inspire
 - **Responsive Design**: Playable on desktop and mobile devices.
 - **Dark Theme Only**: The board is styled dark-only and does not respond to
   a host platform's light theme setting.
+- **Rests When You Do**: A settled board draws no frames at all — the render
+  loop parks itself and the display pipeline goes to 0 fps until you move.
+  With the arcade launcher's **Power Saver** on, the celebratory extras
+  (particles, shockwaves, screen flashes) are dropped as well. The board, the
+  score readouts, and every piece of gameplay motion stay exactly as they are.
 
 ## How to Play
 

--- a/js/frame.js
+++ b/js/frame.js
@@ -1,0 +1,35 @@
+/**
+ * frame.js — the wake-up call for a parked render loop.
+ *
+ * GAME_INTEGRATION §6d: a visible-but-idle game must let the display pipeline
+ * reach 0 fps. Dirty-checking inside a loop that still runs every frame does
+ * not achieve that — the rAF callback itself is the wake-up. So the loop parks
+ * itself (`stop()`) once the board is settled, and anything that creates new
+ * work has to wake it again.
+ *
+ * This module is the seam that lets the low-level modules do that without
+ * importing main.js (which imports them). main.js owns the loop and registers
+ * it here; renderer.requestRedraw() and tween() call wakeFrameLoop().
+ *
+ * Deliberately inert until registered, so the renderer stays importable in
+ * node for the unit tests, where there is no Arcade and no loop at all.
+ */
+
+let loop = null;
+let canRun = () => true;
+
+/**
+ * @param {{start:Function, running:Function}} l — an Arcade.loop handle.
+ * @param {() => boolean} [gate] — false while the game is deliberately parked
+ *        (a modal is open), so a stray redraw can't restart the loop behind it.
+ */
+export function registerFrameLoop(l, gate) {
+  loop = l;
+  if (typeof gate === 'function') canRun = gate;
+}
+
+/** Restart the loop if it has parked. Idempotent and cheap; call it freely. */
+export function wakeFrameLoop() {
+  if (!loop || loop.running() || !canRun()) return;
+  loop.start();
+}

--- a/js/input.js
+++ b/js/input.js
@@ -34,6 +34,13 @@ export function consumeAction() {
 }
 
 /**
+ * Is a gesture still queued? 'rotating' and 'cascading' deliberately do not
+ * consume input, so an action can outlive the frame it arrived on — and the
+ * loop must not park while one is waiting to be answered (§6d).
+ */
+export function hasPendingAction() { return pendingAction !== null; }
+
+/**
  * Trigger an action programmatically (e.g. from UI buttons).
  */
 export function triggerAction(type) {

--- a/js/main.js
+++ b/js/main.js
@@ -37,8 +37,9 @@ import {
 import { hexToPixel, getNeighbors, pixelToHex, findClusterAtPixel } from './hex-math.js';
 import {
   initInput, getHoverCluster, consumeAction, getLastClickPos, triggerAction,
-  setKeyBindings, clearPendingAction, setClusterCenterPx,
+  setKeyBindings, clearPendingAction, setClusterCenterPx, hasPendingAction,
 } from './input.js';
+import { registerFrameLoop, wakeFrameLoop } from './frame.js';
 
 import {
   animateClusterRotation, animateRingRotation, animateYRotation,
@@ -115,6 +116,22 @@ let boardGeneration = 0;  // incremented on grid replacement; stale async chains
 /** True while the board is mid-animation (rotating, cascading). UI should not restart. */
 export function isProcessing() {
   return state === 'rotating' || state === 'cascading';
+}
+
+/**
+ * Come back from a modal. Every close handler goes through here.
+ *
+ * Clearing isPaused is not enough on its own: a paused frame parks the loop,
+ * and a parked loop does not restart just because a flag flipped. That was
+ * already true before §6d — closing help or high-scores left the board frozen
+ * until the next resize or suspend/resume — and the more the loop parks, the
+ * more that bites. Resetting lastTime keeps the score counter from seeing the
+ * whole time the modal was open as one delta.
+ */
+function resumeFromPause() {
+  isPaused = false;
+  lastTime = 0;
+  wakeFrameLoop();
 }
 
 // DEBUG: Expose internals
@@ -245,10 +262,8 @@ document.getElementById('btn-help').addEventListener('click', (e) => {
 });
 document.getElementById('btn-close-help').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = false;
   document.getElementById('modal-help').classList.add('hidden');
-  // Reset lastTime to avoid huge dt jump
-  lastTime = performance.now();
+  resumeFromPause();
 });
 
 // Scores Modal bindings
@@ -260,9 +275,8 @@ document.getElementById('btn-scores').addEventListener('click', (e) => {
 });
 document.getElementById('btn-close-scores').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = false;
   document.getElementById('modal-scores').classList.add('hidden');
-  lastTime = performance.now();
+  resumeFromPause();
 });
 
 // Shared guard: shake a button and bail if board is mid-animation.
@@ -331,10 +345,9 @@ document.getElementById('dropdown-btn-settings').addEventListener('click', (e) =
 });
 document.getElementById('btn-close-settings').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = false;
   document.getElementById('modal-settings').classList.add('hidden');
   saveSettings(settings); // Persist updated bindings
-  lastTime = performance.now();
+  resumeFromPause();
   requestRedraw();
 });
 
@@ -381,7 +394,7 @@ document.getElementById('dropdown-btn-end-session').addEventListener('click', (e
 document.getElementById('btn-cancel-end').addEventListener('click', (e) => {
   e.stopPropagation();
   endSessionModal.classList.add('hidden');
-  isPaused = false;
+  resumeFromPause();
   requestRedraw();
   // allow board interactions again
 });
@@ -393,7 +406,7 @@ document.getElementById('btn-continue-gamewin').addEventListener('click', (e) =>
   setNameFromInput('gw-name');
   document.getElementById('modal-gamewin').classList.add('hidden');
   state = 'idle';
-  isPaused = false;
+  resumeFromPause();
   requestRedraw();
 });
 
@@ -418,7 +431,7 @@ document.getElementById('btn-confirm-end').addEventListener('click', (e) => {
   // Commit the chill-session score before the explosion sequence resets state.
   commitScoreFromInput('es-name');
   endSessionModal.classList.add('hidden');
-  isPaused = false; // Must unpause so the tween game-loop can tick!
+  resumeFromPause(); // Must unpause so the tween game-loop can tick!
   requestRedraw();
 
   // End session logic: trigger explosion sequence
@@ -610,16 +623,52 @@ if (savedState) {
 // resume, and start() is idempotent — it can never stack a second concurrent
 // loop, which is what the restart path used to do.
 const gameFrameLoop = Arcade.loop(gameLoop);
+// Hand the loop to the wake seam so renderer.requestRedraw() and tween() can
+// restart it after it parks. The gate keeps a stray redraw from reviving the
+// loop behind an open modal — that is a deliberate park, not an idle one.
+registerFrameLoop(gameFrameLoop, () => !isPaused);
 gameFrameLoop.start();
 
 // ─── Game loop ──────────────────────────────────────────────────
+
+/**
+ * GAME_INTEGRATION §6d — is there any reason for another frame?
+ *
+ * Dirty-checking the *draw* was never enough: an rAF callback that decides not
+ * to paint is still an rAF callback, so the main thread woke 60x a second on a
+ * settled board and the display pipeline never reached 0 fps. This is the
+ * condition that lets the loop stop entirely.
+ *
+ * isProcessing() ('rotating' / 'cascading') is in here as a deliberate blanket:
+ * those states are driven by async chains that await sleeps between tweens, so
+ * there are moments mid-cascade with nothing dirty and no tween live. Staying
+ * awake through them is a handful of frames during motion the player asked
+ * for, and it means no cascade can strand itself waiting on a parked loop.
+ */
+function nothingLeftToDo() {
+  return !isProcessing()
+    && !getIsDirty()
+    && !hasActiveTweens()
+    && !hasActiveRendererAnimations()
+    && !isScoreAnimating()
+    && !hasPendingAction();
+}
+
+/** Park until something wakes us. */
+function parkFrameLoop() {
+  gameFrameLoop.stop();
+  // The next frame is a fresh start, however long from now that is — leaving
+  // the old timestamp here would hand updateDisplayScore a dt of "however long
+  // the player stared at the board".
+  lastTime = 0;
+}
 
 // Arcade.loop passes (deltaMs, timestamp); the local dt is kept because it
 // carries this game's own 16 ms first-frame default.
 function gameLoop(_deltaMs, timestamp) {
   // Paused means paused: park the loop rather than burning a frame slot each
   // tick to do nothing. onResume/restart start() it again.
-  if (isPaused) { gameFrameLoop.stop(); return; }
+  if (isPaused) { parkFrameLoop(); return; }
 
   const dt = lastTime ? timestamp - lastTime : 16;
   lastTime = timestamp;
@@ -629,14 +678,25 @@ function gameLoop(_deltaMs, timestamp) {
 
   // Game over: just render, no input
   if (state === 'gameover') {
+    // Drain rather than ignore. This branch returns before the consume block,
+    // so a stray keypress behind the game-over modal would sit in the queue
+    // forever — and a queued gesture is one of the reasons the loop refuses to
+    // park, which would leave the longest idle screen in the game running at
+    // full frame rate. It could never be acted on here anyway.
+    clearPendingAction();
+
     const needsDraw = getIsDirty() || hasActiveTweens() || hasActiveRendererAnimations() || isScoreAnimating();
     if (needsDraw) {
       drawFrame(grid, null, null);
       clearDirty();
     }
     // drawGameOver(); // Handled by DOM overlay now
-    
+
     updateGameHUD();
+    // Game over is the longest-lived idle screen there is — the modal sits
+    // there while the player types a name. Once the score counter has caught
+    // up, stop.
+    if (nothingLeftToDo()) parkFrameLoop();
     return;
   }
 
@@ -688,6 +748,10 @@ function gameLoop(_deltaMs, timestamp) {
 
   updateControlsVisibility();
   updateGameHUD();
+
+  // Settled board, no pending gesture, nothing animating: 0 fps until the
+  // player does something. requestRedraw() / tween() bring us back.
+  if (nothingLeftToDo()) parkFrameLoop();
 }
 
 /**

--- a/js/power.js
+++ b/js/power.js
@@ -1,0 +1,43 @@
+/**
+ * power.js — the launcher's power-saver lever, cached and safe to read.
+ *
+ * GAME_INTEGRATION §5 / §6d. When the player turns power saver on, a game
+ * drops ambient and decorative rendering and keeps only gameplay-essential
+ * motion. The setting is pushed on every launcher settings write, so the
+ * cached value is refreshed from onSettingsChange rather than re-read per
+ * frame.
+ *
+ * The read is guarded on purpose. `Arcade.settings.powerSaver` only exists
+ * from SDK 3.13.0; on anything older the property is `undefined` and calling
+ * it throws `TypeError: ... is not a function`. Inside an onSettingsChange
+ * handler that is a throw on *every* settings write, not just at boot — so an
+ * unguarded read would break handedness/font-scale/theme along with it. With
+ * the guard, an older SDK simply degrades to "not saving".
+ */
+
+let saving = readSetting();
+const listeners = [];
+
+function readSetting() {
+  if (typeof Arcade === 'undefined' || !Arcade.settings) return false;
+  return Arcade.settings.powerSaver ? Arcade.settings.powerSaver() : false;
+}
+
+/** True while the player has asked us to spend less battery. */
+export function isPowerSaving() { return saving; }
+
+/** Subscribe to transitions. Called with the new value, only when it changes. */
+export function onPowerSaverChange(fn) { listeners.push(fn); }
+
+/** Re-read and fan out. Exported for tests; wired to onSettingsChange below. */
+export function refreshPowerSaver() {
+  const next = readSetting();
+  if (next === saving) return saving;
+  saving = next;
+  for (const fn of listeners) fn(saving);
+  return saving;
+}
+
+if (typeof Arcade !== 'undefined' && typeof Arcade.onSettingsChange === 'function') {
+  Arcade.onSettingsChange(refreshPowerSaver);
+}

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -13,6 +13,8 @@ import {
 } from './constants.js';
 import { hexToPixel, hexCorners } from './hex-math.js';
 import { getComboCount, getChainLevel } from './score.js';
+import { isPowerSaving, onPowerSaverChange } from './power.js';
+import { wakeFrameLoop } from './frame.js';
 // ─── Module state ───────────────────────────────────────────────
 let ctx;
 let canvasW, canvasH;   // physical CSS pixel dimensions
@@ -22,7 +24,9 @@ let activeGridCols = GRID_COLS;  // current grid dimensions (may differ for puzz
 let activeGridRows = GRID_ROWS;
 
 let isDirty = true;
-export function requestRedraw() { isDirty = true; }
+// The dirty flag and the loop's wake-up are one gesture: a board that is
+// dirty while the loop is parked (§6d) would just sit there unpainted.
+export function requestRedraw() { isDirty = true; wakeFrameLoop(); }
 export function clearDirty() { isDirty = false; }
 export function getIsDirty() { return isDirty; }
 
@@ -200,8 +204,24 @@ export function removeFloatingPiece(piece) {
 }
 
 // ─── Creation Particle API ──────────────────────────────────────
+//
+// Everything below the "decorative" line — particles, ring shockwaves, the
+// full-screen colour wash — is celebration. It says nothing the board does not
+// already say: the match happened, the tiles are gone, the score went up. So
+// under power saver (GAME_INTEGRATION §5 / §6d) it is gated off entirely, and
+// the frames it would have kept alive never get scheduled.
+//
+// Score popups and the combo label are NOT gated: they carry the only readout
+// of how many points a match was worth and what tier the cascade reached.
+// Dropping them would drop information, which is a different thing from
+// dropping decoration.
+//
+// A live effect started before the toggle is dropped too (see the subscription
+// at the bottom of this section) — otherwise turning power saver on mid-cascade
+// buys the player nothing until the current burst finishes.
 
 export function spawnCreationParticles(cx, cy, count = 16) {
+  if (isPowerSaving()) return;
   for (let i = 0; i < count; i++) {
     const angle = (Math.PI * 2 / count) * i + (Math.random() - 0.5) * 0.4;
     const speed = 1.5 + Math.random() * 2.5;
@@ -231,6 +251,7 @@ export function clearCreationParticles() {
  * @param {number} count
  */
 export function spawnColorNukeParticles(cx, cy, colorIndex, count = 40) {
+  if (isPowerSaving()) return;
   const color = PIECE_COLORS[colorIndex];
   // Convert hex color to approximate hue for particle system
   const hueMap = [0, 30, 210, 130, 280]; // red, orange, blue, green, purple
@@ -254,6 +275,7 @@ export function spawnColorNukeParticles(cx, cy, colorIndex, count = 40) {
  * Hot white-to-orange burst — used for mixed-color Explosion.
  */
 export function spawnExplosionParticles(cx, cy, count = 60) {
+  if (isPowerSaving()) return;
   for (let i = 0; i < count; i++) {
     const angle = (Math.PI * 2 / count) * i + (Math.random() - 0.5) * 0.5;
     const speed = 4 + Math.random() * 6;
@@ -280,8 +302,9 @@ export function spawnExplosionParticles(cx, cy, count = 60) {
  * @param {number} bb - blue 0-255
  */
 export function spawnRingShockwave(cx, cy, maxRadius, rr, gg, bb) {
+  if (isPowerSaving()) return;
   shockwaves.push({ x: cx, y: cy, r: 0, maxR: maxRadius, life: 1.0, maxLife: 40, rr, gg, bb });
-  isDirty = true;
+  requestRedraw();
 }
 
 /**
@@ -293,9 +316,22 @@ export function spawnRingShockwave(cx, cy, maxRadius, rr, gg, bb) {
  * @param {number} maxLife - lifetime in draw frames (approx 60fps)
  */
 export function flashScreenOverlay(rr, gg, bb, peakAlpha = 0.25, maxLife = 30) {
+  if (isPowerSaving()) return;
   screenOverlay = { rr, gg, bb, alpha: peakAlpha, life: 1.0, maxLife };
-  isDirty = true;
+  requestRedraw();
 }
+
+// Turning the lever on mid-burst drops what is already in flight. The board
+// itself is untouched — only the confetti over it goes away — so there is no
+// state to lose. One last redraw paints the frame without them; after that
+// hasActiveRendererAnimations() is false and the loop is free to park.
+onPowerSaverChange((saving) => {
+  if (!saving) return;
+  creationParticles = [];
+  shockwaves = [];
+  screenOverlay = null;
+  requestRedraw();
+});
 
 // ─── Main draw ──────────────────────────────────────────────────
 

--- a/js/tween.js
+++ b/js/tween.js
@@ -7,6 +7,8 @@
  *   t.cancel()  – stop early
  */
 
+import { wakeFrameLoop } from './frame.js';
+
 const active = [];
 
 export function tween(durationMs, onUpdate, easing = easeOutCubic) {
@@ -15,6 +17,11 @@ export function tween(durationMs, onUpdate, easing = easeOutCubic) {
   const reducedMotion = typeof Arcade !== 'undefined' && Arcade.settings.reducedMotion();
   const entry = { start: -1, duration: reducedMotion ? 0 : durationMs, onUpdate, easing, resolve, cancelled: false };
   active.push(entry);
+  // updateTweens only runs from the game loop, and the loop parks itself when
+  // the board settles (§6d). A tween started from a parked state would never
+  // advance and its promise would never resolve — which, since the cascade
+  // chains await these, means a hung board. Wake it here.
+  wakeFrameLoop();
   return {
     promise,
     cancel() { entry.cancelled = true; },

--- a/tests/helpers/fake-arcade.mjs
+++ b/tests/helpers/fake-arcade.mjs
@@ -1,0 +1,37 @@
+/**
+ * fake-arcade.mjs — the slice of the launcher SDK the power-saver modules read.
+ *
+ * Must be installed on globalThis *before* the modules under test are
+ * imported: they subscribe to onSettingsChange at evaluation time, which is
+ * the whole point (a settings handler is where an unguarded read does its
+ * damage).
+ */
+
+/**
+ * @param {object}  [opts]
+ * @param {boolean} [opts.powerSaver]  initial value of the setting
+ * @param {boolean} [opts.reducedMotion]
+ * @param {'current'|'legacy'} [opts.sdk] — 'legacy' models anything older than
+ *        SDK 3.13.0, where `Arcade.settings.powerSaver` does not exist at all
+ *        and calling it throws.
+ */
+export function installArcade({ powerSaver = false, reducedMotion = false, sdk = 'current' } = {}) {
+  let value = powerSaver;
+  const handlers = [];
+  const settings = { reducedMotion: () => reducedMotion };
+  if (sdk !== 'legacy') settings.powerSaver = () => value;
+
+  globalThis.Arcade = {
+    settings,
+    onSettingsChange: (fn) => { handlers.push(fn); },
+  };
+
+  return {
+    /** What the launcher does on a settings write: change, then fan out. */
+    push(next) {
+      value = next;
+      for (const fn of handlers) fn({ powerSaver: next, reducedMotion });
+    },
+    handlerCount: () => handlers.length,
+  };
+}

--- a/tests/power-saver-legacy.test.js
+++ b/tests/power-saver-legacy.test.js
@@ -1,0 +1,31 @@
+/**
+ * power-saver-legacy.test.js — the guarded read, against a pre-3.13 SDK.
+ *
+ * Its own file because the fake launcher has to be installed before the module
+ * graph is evaluated, and node's test runner gives each file its own process.
+ *
+ * Why this is worth a test of its own: `Arcade.settings.powerSaver` arrived in
+ * SDK 3.13.0. Written the obvious way, the read is a TypeError on anything
+ * older — and not just at boot. The subscription fires on *every* launcher
+ * settings write, so an unguarded call throws inside the settings handler and
+ * takes handedness, font scale and theme down with it, on a game that would
+ * otherwise have degraded quietly to "not saving".
+ */
+import test from 'node:test';
+import assert from 'node:assert';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+const launcher = installArcade({ sdk: 'legacy' });
+const power = await import('../js/power.js');
+
+test('a missing powerSaver method reads as false rather than throwing', () => {
+  assert.strictEqual(power.isPowerSaving(), false);
+});
+
+test('a settings change against a legacy SDK does not throw', () => {
+  assert.strictEqual(launcher.handlerCount(), 1,
+    'precondition: power.js subscribed to onSettingsChange');
+  assert.doesNotThrow(() => launcher.push(true));
+  assert.strictEqual(power.isPowerSaving(), false,
+    'an older SDK has no such setting — it degrades to "not saving"');
+});

--- a/tests/power-saver.test.js
+++ b/tests/power-saver.test.js
@@ -1,0 +1,149 @@
+/**
+ * power-saver.test.js — GAME_INTEGRATION §5 / §6d, the parts a node test can
+ * actually pin.
+ *
+ * The end-to-end claim (§6d: "a flat main thread and 0 fps between state
+ * changes") is a browser measurement and lives in the Playwright acceptance
+ * run, not here. What is testable in-process is everything that measurement
+ * depends on:
+ *
+ *   - the decorative/informational split, so a later "just add a sparkle"
+ *     lands on the gated side by default;
+ *   - the wake seam, because a loop that parks and never comes back is a much
+ *     worse bug than a loop that never parks;
+ *   - the no-infinite-animations gate over the stylesheets.
+ *
+ * The guarded read against a pre-3.13 SDK is its own file, because it needs a
+ * different Arcade installed before the module graph is evaluated and node
+ * gives each test file its own process.
+ *
+ * Everything is imported once, at the top, against one fake launcher — the
+ * modules under test import each other by plain specifier, so per-test cache
+ * busting would hand each test a different copy of the seam it is asserting on.
+ */
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { ROOT } from '../tools/stage.mjs';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+const launcher = installArcade({ powerSaver: false });
+
+const power    = await import('../js/power.js');
+const frame    = await import('../js/frame.js');
+const renderer = await import('../js/renderer.js');
+const { tween } = await import('../js/tween.js');
+
+/** Every decorative effect the game can throw, in one call. */
+function spawnAllDecoration() {
+  renderer.spawnCreationParticles(10, 10, 8);
+  renderer.spawnExplosionParticles(10, 10, 8);
+  renderer.spawnColorNukeParticles(10, 10, 0, 8);
+  renderer.spawnRingShockwave(10, 10, 100, 255, 0, 0);
+  renderer.flashScreenOverlay(255, 0, 0, 0.2, 30);
+}
+
+test('powerSaver tracks the launcher and notifies only on a real change', () => {
+  launcher.push(false);
+  const seen = [];
+  power.onPowerSaverChange((v) => seen.push(v));
+
+  assert.strictEqual(power.isPowerSaving(), false);
+  launcher.push(true);
+  assert.strictEqual(power.isPowerSaving(), true);
+  launcher.push(true);   // a settings write that didn't touch this setting
+  launcher.push(false);
+
+  assert.deepStrictEqual(seen, [true, false],
+    'subscribers should see transitions, not every settings write');
+});
+
+test('power saver drops decoration and keeps the readouts', () => {
+  launcher.push(false);
+  spawnAllDecoration();
+  assert.strictEqual(renderer.hasActiveRendererAnimations(), true,
+    'precondition: decorative effects are live with the lever off');
+
+  // Flipping it on drops what is already in flight — otherwise the player pays
+  // for the rest of the current cascade before the setting means anything.
+  launcher.push(true);
+  assert.strictEqual(renderer.hasActiveRendererAnimations(), false,
+    'a live burst must be cleared when power saver comes on, not merely stopped ' +
+    'from respawning — while any of it is alive the loop cannot park');
+
+  spawnAllDecoration();
+  assert.strictEqual(renderer.hasActiveRendererAnimations(), false,
+    'every decorative spawner must be a no-op under power saver');
+
+  // The informational half is untouched: a score popup is the only readout of
+  // what a match was worth, and dropping it would drop information rather than
+  // decoration.
+  renderer.spawnScorePopup(10, 10, 500, 2);
+  assert.strictEqual(renderer.hasActiveRendererAnimations(), true,
+    'power saver must not silence the score popup');
+  launcher.push(false);
+  launcher.push(true);   // a full transition, which fires the clear
+  assert.strictEqual(renderer.hasActiveRendererAnimations(), true,
+    'the clear must take the confetti and leave the readout');
+});
+
+test('a parked loop is woken by a redraw request and by a new tween', () => {
+  launcher.push(false);
+
+  let running = false;
+  let starts = 0;
+  let gateOpen = true;
+  frame.registerFrameLoop(
+    { start() { running = true; starts++; }, running: () => running },
+    () => gateOpen,
+  );
+
+  // Parked, as it is whenever the board is settled.
+  running = false;
+  renderer.requestRedraw();
+  assert.strictEqual(starts, 1, 'requestRedraw() must restart a parked loop');
+
+  running = false;
+  tween(100, () => {});
+  assert.strictEqual(starts, 2,
+    'a tween started from a parked state would never advance and its promise ' +
+    'would never resolve — the cascade chains await these');
+
+  // Already running: no redundant start.
+  running = true;
+  renderer.requestRedraw();
+  assert.strictEqual(starts, 2, 'waking a running loop should be a no-op');
+
+  // A modal is a deliberate park, not an idle one: a stray redraw behind it
+  // must not put frames back on the schedule.
+  running = false;
+  gateOpen = false;
+  renderer.requestRedraw();
+  tween(100, () => {});
+  assert.strictEqual(starts, 2, 'the gate must hold the loop parked while paused');
+});
+
+test('no infinite CSS animation ships — §6d, "let the screen rest"', () => {
+  const tracked = execSync('git ls-files -z', { cwd: ROOT, encoding: 'utf8' })
+    .split('\0').filter(Boolean)
+    .filter((f) => /\.(css|html)$/.test(f));
+  assert.ok(tracked.length > 0, 'precondition: found stylesheets to check');
+
+  const offenders = [];
+  for (const f of tracked) {
+    const src = fs.readFileSync(path.join(ROOT, f), 'utf8');
+    src.split('\n').forEach((line, i) => {
+      // Either spelling: the shorthand's keyword, or the longhand property.
+      if (/animation(-iteration-count)?\s*:[^;}]*\binfinite\b/.test(line)) {
+        offenders.push(`${f}:${i + 1}: ${line.trim()}`);
+      }
+    });
+  }
+  assert.deepStrictEqual(offenders, [],
+    'An infinite animation is a rAF loop that never stops, written declaratively — ' +
+    'a visible-but-idle game can never reach 0 fps while one runs. Pulse finitely ' +
+    'with `animation-iteration-count: var(--arcade-pulse-count, 3)` and settle to a ' +
+    'static resting treatment that still reads.');
+});


### PR DESCRIPTION
Closes #56. Adopts the arcade power-saver contract — GAME_INTEGRATION §5 and §6d ("Let the screen rest").

Two halves: the loop stops when there is nothing to draw, and the player's power-saver lever drops the decorative tier on top of that.

**Dirty-checking the draw was never enough.** `gameLoop` already skipped `drawFrame` when nothing was dirty, which reads like compliance and isn't — an rAF callback that decides not to paint is still an rAF callback. A settled board woke the main thread 60 times a second to walk `updateTweens` / `updateDisplayScore` / `updateControlsVisibility` / `updateGameHUD` and do nothing with the result, so the display pipeline never reached 0 fps. That is exactly the visible-but-idle case §6d is about, and the one a turn-based match-3 spends most of its life in. The loop now `stop()`s when `nothingLeftToDo()`: not processing, not dirty, no tweens, no renderer animations, score counter settled, no queued gesture. `isProcessing()` is a deliberate blanket — `rotating`/`cascading` are async chains that await sleeps between tweens, so there are moments mid-cascade with nothing live; staying awake through them costs a handful of frames during motion the player asked for and guarantees no cascade can strand itself against a parked loop. Waking back up goes through one seam (`js/frame.js`) that `renderer.requestRedraw()` and `tween()` both call, so nothing else had to learn about the loop.

**A modal close never restarted the loop.** Pre-existing, but this change makes it load-bearing. Six handlers set `isPaused = false` and stopped there; since #55 the paused frame calls `loop.stop()`, and a stopped loop does not restart because a flag flipped — so closing help / high-scores / settings left the board frozen until the next resize or suspend-resume. They all go through `resumeFromPause()` now. The gate on the wake seam matters here: a keypress behind an open modal queues an action and requests a redraw, and that must *not* put frames back on the schedule — a modal is a deliberate park, not an idle one. The game-over branch also drains input now, since it returns before the consume block and a stray keypress would otherwise sit queued forever, pinning the longest-lived idle screen in the game at full frame rate.

**Power saver gates the decorative tier.** Particles, ring shockwaves and the full-screen colour wash say nothing the board does not already say, so their spawners are no-ops under power saver, and flipping the lever on mid-cascade clears what is already in flight. Score popups and the combo label are deliberately **not** gated — they carry the only readout of what a match was worth, and dropping them would drop information rather than decoration. Gameplay motion (rotation arcs, gravity, the bomb-fuse shake) is untouched.

The read is guarded per §5 — `Arcade.settings.powerSaver ? Arcade.settings.powerSaver() : false`, cached in `js/power.js` and refreshed from `onSettingsChange`. On a pre-3.13 SDK the unguarded form throws not just at boot but on *every* launcher settings write, taking handedness, font scale and theme down with it; guarded, an older SDK degrades to "not saving". **No SDK version change is needed** here or anywhere: this repo loads the launcher's SDK at the pinned URL, and the CSS half carries its own `var()` fallback.

### Two things deliberately not done

**No `--arcade-pulse-count` declaration** — there is nothing to declare it on. This game ships no infinite CSS animation; the two keyframe effects it has (`shake`, `star-pop`) are single-shot with fill `both`, and writing the token onto them would turn one shake into three. A test gate now holds that line over every tracked stylesheet, with the §6d reasoning in the failure message, so an infinite pulse can't arrive later unnoticed.

**No frame-rate cap** — it was on the table (the issue says "consider") and it is the wrong lever here. Particle, shockwave and score-popup lifetimes are counted in *frames*, not milliseconds, so halving the rate would stretch every one of them; and a match-3 cascade is precisely the gameplay-essential motion §5 says to leave alone. Parking at 0 fps between state changes is where the battery actually is.

### Verification

Suite: **88/88** (was 82). New: `tests/power-saver.test.js` (decorative/informational split, the wake seam including the paused gate, the no-infinite-animation gate) and `tests/power-saver-legacy.test.js` (the guarded read against a pre-3.13 SDK, in its own process so the fake launcher is installed before the module graph evaluates).

The §6d acceptance bar is a browser measurement, so it was taken in one: headless Chromium against the launcher + game staged on a single origin, counting rAF callbacks (a rAF callback *is* a frame the compositor was kept awake for).

| check | result |
| --- | --- |
| booted, visible, idle — 3s | **0 frames** |
| after a click settles — 2s | **0 frames** |
| after a rotation + full cascade resolves — 3s | **0 frames** |
| help modal open — 2s | **0 frames** |
| keypresses (`q`, `e`) behind an open modal | **0 frames** |
| high-scores modal open — 2s | **0 frames** |
| after a live `powerSaver` flip mid-session | **0 frames** |
| power saver on from boot, idle — 3s | **0 frames** |
| during a rotation | ~19 frames — gameplay motion intact |
| parked board is painted, not blank | 288 distinct sampled colours |
| input after every modal close / mode switch | still lands |
| page errors | 0 |

Also confirmed on the game side: `data-power-saver` flips mid-session, `Arcade.settings.powerSaver()` reads `true`, and `--arcade-pulse-count` resolves to `1` under power saver.

Reduced motion is unchanged — nothing in this change touches the tween short-circuit or the CSS kill rule, and a reduced-motion tween still gets its one instantaneous frame because the wake seam schedules it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
