### PR TITLE
Cancel in-progress runs for pull requests only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,9 +15,14 @@ permissions:
   id-token: write
 
 # Per-ref, so a PR run never cancels main's deploy.
+#
+# Cancelling is for PRs ONLY. A main run cancelled mid-deploy can have already
+# pushed the version bump without publishing it, leaving the origin serving a
+# version that no longer matches the repo — the exact drift the bump exists
+# to prevent. Pushes to main queue and drain instead.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   fleet:


### PR DESCRIPTION
Cancelling in-progress runs is right for pull requests and wrong for main.

A push to main that gets cancelled by the next push can be cancelled at any
point — including between the version-bump commit being pushed back and
actions/deploy-pages publishing. That leaves the repo carrying a version the
origin has never served, which is precisely the drift CI owning the version
exists to prevent. It self-heals on the next deploy, but the window is real
and there is nothing to gain by racing: main runs should queue and drain.

PR runs keep cancelling, which is where the behaviour actually pays for
itself — pushing three times to a branch should not leave three runs going.

Fleet-wide change; every caller gets the same edit.

Part of the fleet-wide pipeline pass in the launcher (paulgibeault/paulgibeault.github.io#139), which fixes the same stanza there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)