### PR TITLE
DO NOT MERGE — canary for launcher PR #139

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,10 @@ jobs:
   fleet:
     uses: paulgibeault/paulgibeault.github.io/.github/workflows/fleet-ci.yml@ci/pipeline-hardening
     with:
+      # Pins the SECOND half. Without it the run takes the branch's YAML
+      # and main's scripts, which is how this canary failed twice.
+      toolchain_ref: ci/pipeline-hardening
+    with:
       # This app cache-busts its PWA via a deploy-time patch bump
       # (package.json, manifest start_url, index.html badge).
       version_bump: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   fleet:
-    uses: paulgibeault/paulgibeault.github.io/.github/workflows/fleet-ci.yml@main
+    uses: paulgibeault/paulgibeault.github.io/.github/workflows/fleet-ci.yml@ci/pipeline-hardening
     with:
       # This app cache-busts its PWA via a deploy-time patch bump
       # (package.json, manifest start_url, index.html badge).

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,6 @@ jobs:
       # Pins the SECOND half. Without it the run takes the branch's YAML
       # and main's scripts, which is how this canary failed twice.
       toolchain_ref: ci/pipeline-hardening
-    with:
       # This app cache-busts its PWA via a deploy-time patch bump
       # (package.json, manifest start_url, index.html badge).
       version_bump: true


### PR DESCRIPTION
Throwaway draft. Pins this repo's caller at `fleet-ci.yml@ci/pipeline-hardening` to exercise the **game-side** path of the reworked pipeline, which nothing else can reach before merge:

- the `.launcher-gates` checkout in the `test` job
- the `smoke` job's `npm ci` + Chromium install inside `.launcher-gates`
- `stage-dispatch.mjs` resolved from the launcher instead of from this repo

The launcher's own PR has all of those files locally, so it takes the other branch every time; the concurrency PRs call `@main`, which is still the old pipeline. hecknsic is the plain-game shape — no `launcher:`, no `browsers:` — which six of the nine callers share.

Will be closed unmerged. See paulgibeault/paulgibeault.github.io#139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)