### PR TITLE
Architecture work packages: three bug fixes and the structure that prevents them (#62–#67)

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -2,7 +2,7 @@ import {
   MATCH_FLASH_MS, GRAVITY_MS,
   ROTATION_POP_MS, ROTATION_SETTLE_MS
 } from './constants.js';
-import { rotateCluster, rotateRing, applyGravity, fillEmpty } from './board.js';
+import { rotateCluster, rotateRing } from './board.js';
 import {
   setCellOverride, clearAllOverrides,
   addFloatingPiece, removeFloatingPiece,
@@ -10,28 +10,52 @@ import {
   spawnColorNukeParticles, spawnExplosionParticles, spawnScorePopup, flashScreenOverlay,
   getOrigin
 } from './renderer.js';
-import { getActiveGameMode } from './modes.js';
 import { hexToPixel, getNeighbors } from './hex-math.js';
 import { tween, easeOutCubic, easeOutBounce, linear } from './tween.js';
-import { awardMatch, getChainLevel, getScore, getMaxCombo } from './score.js';
+import { awardMatch, getChainLevel } from './score.js';
 import {
   detectStarflowersAtCleared, detectBlackPearls, detectMultiplierClusters
 } from './specials.js';
 import { onStarflowerCreated } from './puzzle-mode.js';
-import { openModal } from './modal.js';
-import { recordGameEnd } from './storage.js';
-import { prepopulateNameInputs } from './ui.js';
-import { playGameOver, playOverAchiever, stopBed } from './audio.js';
 
-/** Animate 3-hex cluster rotation (original pop-thunk) */
+/**
+ * animations.js — the board in motion.
+ *
+ * TWO RULES, both of them hecknsic#66:
+ *
+ * 1. No DOM. Nothing here reaches for a document; the end-of-run modals used
+ *    to be written from inside handleGameOver()/handleOverAchiever() and now
+ *    live behind game-state.js's host, which main.js registers. What is left
+ *    of the explosion is explodeBoard(). A repo gate in tests/cancellation.test.js
+ *    holds the line.
+ *
+ * 2. No state transitions. `ctx` is read-only apart from the board cells these
+ *    functions exist to move and settleBoard(), which is game-state.js's own
+ *    function. An animation reports what happened by returning; deciding what
+ *    that means is the state machine's job.
+ *
+ * CANCELLATION. Every chain in here carries `ctx.token`, minted for the board
+ * it started on (js/cancel.js). Awaiting through `token.tween(…)` /
+ * `token.delay(…)` throws Cancelled the moment that board is replaced, so a
+ * rotation whose board is swapped out from under it unwinds instead of
+ * committing three cells of the old board onto the new one (hecknsic#62,
+ * pinned by tests/rotation-cancel.test.js). Anything allocated across an await
+ * — floating pieces, in practice — is released in a `finally`, because the
+ * throw skips whatever came after it.
+ */
+
+/** Animate 3-hex cluster rotation (original pop-thunk).
+ *  @returns {Promise<boolean>} false if the cells it was asked to turn are no
+ *  longer on the board — the caller owns the state change that follows.
+ *  @throws {Cancelled} if the board is replaced mid-rotation. */
 export async function animateClusterRotation(ctx, clockwise, originX, originY) {
-  const gen = ctx.boardGeneration;
+  const token = ctx.token;
   const cluster = ctx.selectedCluster;
   const pixelPos = cluster.map(h => hexToPixel(h.col, h.row, originX, originY));
   const cx = (pixelPos[0].x + pixelPos[1].x + pixelPos[2].x) / 3;
   const cy = (pixelPos[0].y + pixelPos[1].y + pixelPos[2].y) / 3;
   const cells = cluster.map(h => ctx.grid[h.col]?.[h.row]);
-  if (cells.some(c => !c)) { ctx.setState('idle'); return; }
+  if (cells.some(c => !c)) return false;
   const colors = cells.map(c => c.colorIndex);
   const specials = cells.map(c => c.special);
 
@@ -44,55 +68,63 @@ export async function animateClusterRotation(ctx, clockwise, originX, originY) {
     });
   });
 
-  // Pop
-  await tween(ROTATION_POP_MS, t => {
-    for (const fp of floaters) { fp.scale = 1 + 0.2 * t; fp.shadow = t > 0.3; }
-  }, easeOutCubic).promise;
-
   const targets = clockwise
     ? [pixelPos[1], pixelPos[2], pixelPos[0]]
     : [pixelPos[2], pixelPos[0], pixelPos[1]];
-  const startPos = floaters.map(fp => ({ x: fp.x, y: fp.y }));
+  let startPos;
 
-  // Arc
-  await tween(ROTATION_SETTLE_MS * 0.6, t => {
-    for (let i = 0; i < 3; i++) {
-      const a0 = Math.atan2(startPos[i].y - cy, startPos[i].x - cx);
-      const a1 = Math.atan2(targets[i].y - cy, targets[i].x - cx);
-      let da = a1 - a0;
-      if (clockwise && da > 0) da -= Math.PI * 2;
-      if (!clockwise && da < 0) da += Math.PI * 2;
-      const angle = a0 + da * t;
-      const r0 = Math.hypot(startPos[i].x - cx, startPos[i].y - cy);
-      const r1 = Math.hypot(targets[i].x - cx, targets[i].y - cy);
-      const radius = r0 + (r1 - r0) * t;
-      floaters[i].x = cx + Math.cos(angle) * radius;
-      floaters[i].y = cy + Math.sin(angle) * radius;
-    }
-  }, easeOutCubic).promise;
-
-  // Settle
-  await tween(ROTATION_SETTLE_MS * 0.4, t => {
-    for (let i = 0; i < 3; i++) {
-      floaters[i].x = targets[i].x;
-      floaters[i].y = targets[i].y;
-      floaters[i].scale = 1 + 0.2 * (1 - t);
-      floaters[i].shadow = t < 0.7;
-    }
-  }, easeOutBounce).promise;
-
-  for (const fp of floaters) removeFloatingPiece(fp);
   // The board can be swapped out from under an in-flight rotation (mode
   // switch, puzzle load, restart). Rotating now would scramble three cells of
-  // the fresh board, and clearAllOverrides() would wipe the overrides it set.
-  if (ctx.boardGeneration !== gen) return;
+  // the fresh board, and clearAllOverrides() would wipe the overrides it set —
+  // so any of these three awaits throws Cancelled rather than returning here,
+  // and the floating pieces are released on the way out either way.
+  try {
+    // Pop
+    await token.tween(ROTATION_POP_MS, t => {
+      for (const fp of floaters) { fp.scale = 1 + 0.2 * t; fp.shadow = t > 0.3; }
+    }, easeOutCubic);
+
+    startPos = floaters.map(fp => ({ x: fp.x, y: fp.y }));
+
+    // Arc
+    await token.tween(ROTATION_SETTLE_MS * 0.6, t => {
+      for (let i = 0; i < 3; i++) {
+        const a0 = Math.atan2(startPos[i].y - cy, startPos[i].x - cx);
+        const a1 = Math.atan2(targets[i].y - cy, targets[i].x - cx);
+        let da = a1 - a0;
+        if (clockwise && da > 0) da -= Math.PI * 2;
+        if (!clockwise && da < 0) da += Math.PI * 2;
+        const angle = a0 + da * t;
+        const r0 = Math.hypot(startPos[i].x - cx, startPos[i].y - cy);
+        const r1 = Math.hypot(targets[i].x - cx, targets[i].y - cy);
+        const radius = r0 + (r1 - r0) * t;
+        floaters[i].x = cx + Math.cos(angle) * radius;
+        floaters[i].y = cy + Math.sin(angle) * radius;
+      }
+    }, easeOutCubic);
+
+    // Settle
+    await token.tween(ROTATION_SETTLE_MS * 0.4, t => {
+      for (let i = 0; i < 3; i++) {
+        floaters[i].x = targets[i].x;
+        floaters[i].y = targets[i].y;
+        floaters[i].scale = 1 + 0.2 * (1 - t);
+        floaters[i].shadow = t < 0.7;
+      }
+    }, easeOutBounce);
+  } finally {
+    for (const fp of floaters) removeFloatingPiece(fp);
+  }
+
   clearAllOverrides();
   rotateCluster(ctx.grid, cluster, clockwise);
+  return true;
 }
 
-/** Animate 6-hex ring rotation around flower center */
+/** Animate 6-hex ring rotation around flower center. @returns {Promise<boolean>}
+ *  @throws {Cancelled} if the board is replaced mid-rotation. */
 export async function animateRingRotation(ctx, clockwise, originX, originY) {
-  const gen = ctx.boardGeneration;
+  const token = ctx.token;
   const center = ctx.flowerCenter;
   const ring = getNeighbors(center.col, center.row);
   const centerPx = hexToPixel(center.col, center.row, originX, originY);
@@ -101,7 +133,7 @@ export async function animateRingRotation(ctx, clockwise, originX, originY) {
 
   const pixelPos = ring.map(h => hexToPixel(h.col, h.row, originX, originY));
   const ringCells = ring.map(h => ctx.grid[h.col]?.[h.row]);
-  if (ringCells.some(c => !c)) { ctx.setState('idle'); return; }
+  if (ringCells.some(c => !c)) return false;
   const colors = ringCells.map(c => c.colorIndex);
   const specials = ringCells.map(c => c.special);
 
@@ -115,53 +147,59 @@ export async function animateRingRotation(ctx, clockwise, originX, originY) {
     });
   });
 
-  // Pop
-  await tween(ROTATION_POP_MS, t => {
-    for (const fp of floaters) { fp.scale = 1 + 0.15 * t; fp.shadow = t > 0.3; }
-  }, easeOutCubic).promise;
-
   // Targets: each piece moves one position CW or CCW
   const targets = clockwise
     ? ring.map((_, i) => pixelPos[(i + 1) % 6])
     : ring.map((_, i) => pixelPos[(i + 5) % 6]);
-  const startPos = floaters.map(fp => ({ x: fp.x, y: fp.y }));
+  let startPos;
 
-  // Arc around center
-  await tween(ROTATION_SETTLE_MS * 0.7, t => {
-    for (let i = 0; i < 6; i++) {
-      const a0 = Math.atan2(startPos[i].y - cy, startPos[i].x - cx);
-      const a1 = Math.atan2(targets[i].y - cy, targets[i].x - cx);
-      let da = a1 - a0;
-      if (clockwise && da > 0) da -= Math.PI * 2;
-      if (!clockwise && da < 0) da += Math.PI * 2;
-      const angle = a0 + da * t;
-      const r0 = Math.hypot(startPos[i].x - cx, startPos[i].y - cy);
-      const r1 = Math.hypot(targets[i].x - cx, targets[i].y - cy);
-      const radius = r0 + (r1 - r0) * t;
-      floaters[i].x = cx + Math.cos(angle) * radius;
-      floaters[i].y = cy + Math.sin(angle) * radius;
-    }
-  }, easeOutCubic).promise;
+  try {
+    // Pop
+    await token.tween(ROTATION_POP_MS, t => {
+      for (const fp of floaters) { fp.scale = 1 + 0.15 * t; fp.shadow = t > 0.3; }
+    }, easeOutCubic);
 
-  // Settle
-  await tween(ROTATION_SETTLE_MS * 0.3, t => {
-    for (let i = 0; i < 6; i++) {
-      floaters[i].x = targets[i].x;
-      floaters[i].y = targets[i].y;
-      floaters[i].scale = 1 + 0.15 * (1 - t);
-      floaters[i].shadow = t < 0.7;
-    }
-  }, easeOutBounce).promise;
+    startPos = floaters.map(fp => ({ x: fp.x, y: fp.y }));
 
-  for (const fp of floaters) removeFloatingPiece(fp);
-  if (ctx.boardGeneration !== gen) return; // board was replaced mid-rotation
+    // Arc around center
+    await token.tween(ROTATION_SETTLE_MS * 0.7, t => {
+      for (let i = 0; i < 6; i++) {
+        const a0 = Math.atan2(startPos[i].y - cy, startPos[i].x - cx);
+        const a1 = Math.atan2(targets[i].y - cy, targets[i].x - cx);
+        let da = a1 - a0;
+        if (clockwise && da > 0) da -= Math.PI * 2;
+        if (!clockwise && da < 0) da += Math.PI * 2;
+        const angle = a0 + da * t;
+        const r0 = Math.hypot(startPos[i].x - cx, startPos[i].y - cy);
+        const r1 = Math.hypot(targets[i].x - cx, targets[i].y - cy);
+        const radius = r0 + (r1 - r0) * t;
+        floaters[i].x = cx + Math.cos(angle) * radius;
+        floaters[i].y = cy + Math.sin(angle) * radius;
+      }
+    }, easeOutCubic);
+
+    // Settle
+    await token.tween(ROTATION_SETTLE_MS * 0.3, t => {
+      for (let i = 0; i < 6; i++) {
+        floaters[i].x = targets[i].x;
+        floaters[i].y = targets[i].y;
+        floaters[i].scale = 1 + 0.15 * (1 - t);
+        floaters[i].shadow = t < 0.7;
+      }
+    }, easeOutBounce);
+  } finally {
+    for (const fp of floaters) removeFloatingPiece(fp);
+  }
+
   clearAllOverrides();
   rotateRing(ctx.grid, ring, clockwise);
+  return true;
 }
 
-/** Animate 3-hex Y-shape rotation around black pearl center */
+/** Animate 3-hex Y-shape rotation around black pearl center.
+ *  @returns {Promise<boolean>} @throws {Cancelled} */
 export async function animateYRotation(ctx, clockwise, originX, originY) {
-  const gen = ctx.boardGeneration;
+  const token = ctx.token;
   const center = ctx.pearlCenter;
   const nbrs = getNeighbors(center.col, center.row);
   // Y-shape uses alternating neighbors (0, 2, 4)
@@ -172,7 +210,7 @@ export async function animateYRotation(ctx, clockwise, originX, originY) {
 
   const pixelPos = yRing.map(h => hexToPixel(h.col, h.row, originX, originY));
   const yCells = yRing.map(h => ctx.grid[h.col]?.[h.row]);
-  if (yCells.some(c => !c)) { ctx.setState('idle'); return; }
+  if (yCells.some(c => !c)) return false;
   const colors = yCells.map(c => c.colorIndex);
   const specials = yCells.map(c => c.special);
 
@@ -186,46 +224,50 @@ export async function animateYRotation(ctx, clockwise, originX, originY) {
     });
   });
 
-  // Pop
-  await tween(ROTATION_POP_MS, t => {
-    for (const fp of floaters) { fp.scale = 1 + 0.15 * t; fp.shadow = t > 0.3; }
-  }, easeOutCubic).promise;
-
   // Targets: each piece moves to the next position in the Y
   const targets = clockwise
     ? [pixelPos[1], pixelPos[2], pixelPos[0]]
     : [pixelPos[2], pixelPos[0], pixelPos[1]];
-  const startPos = floaters.map(fp => ({ x: fp.x, y: fp.y }));
+  let startPos;
 
-  // Arc around center
-  await tween(ROTATION_SETTLE_MS * 0.7, t => {
-    for (let i = 0; i < 3; i++) {
-      const a0 = Math.atan2(startPos[i].y - cy, startPos[i].x - cx);
-      const a1 = Math.atan2(targets[i].y - cy, targets[i].x - cx);
-      let da = a1 - a0;
-      if (clockwise && da > 0) da -= Math.PI * 2;
-      if (!clockwise && da < 0) da += Math.PI * 2;
-      const angle = a0 + da * t;
-      const r0 = Math.hypot(startPos[i].x - cx, startPos[i].y - cy);
-      const r1 = Math.hypot(targets[i].x - cx, targets[i].y - cy);
-      const radius = r0 + (r1 - r0) * t;
-      floaters[i].x = cx + Math.cos(angle) * radius;
-      floaters[i].y = cy + Math.sin(angle) * radius;
-    }
-  }, easeOutCubic).promise;
+  try {
+    // Pop
+    await token.tween(ROTATION_POP_MS, t => {
+      for (const fp of floaters) { fp.scale = 1 + 0.15 * t; fp.shadow = t > 0.3; }
+    }, easeOutCubic);
 
-  // Settle
-  await tween(ROTATION_SETTLE_MS * 0.3, t => {
-    for (let i = 0; i < 3; i++) {
-      floaters[i].x = targets[i].x;
-      floaters[i].y = targets[i].y;
-      floaters[i].scale = 1 + 0.15 * (1 - t);
-      floaters[i].shadow = t < 0.7;
-    }
-  }, easeOutBounce).promise;
+    startPos = floaters.map(fp => ({ x: fp.x, y: fp.y }));
 
-  for (const fp of floaters) removeFloatingPiece(fp);
-  if (ctx.boardGeneration !== gen) return; // board was replaced mid-rotation
+    // Arc around center
+    await token.tween(ROTATION_SETTLE_MS * 0.7, t => {
+      for (let i = 0; i < 3; i++) {
+        const a0 = Math.atan2(startPos[i].y - cy, startPos[i].x - cx);
+        const a1 = Math.atan2(targets[i].y - cy, targets[i].x - cx);
+        let da = a1 - a0;
+        if (clockwise && da > 0) da -= Math.PI * 2;
+        if (!clockwise && da < 0) da += Math.PI * 2;
+        const angle = a0 + da * t;
+        const r0 = Math.hypot(startPos[i].x - cx, startPos[i].y - cy);
+        const r1 = Math.hypot(targets[i].x - cx, targets[i].y - cy);
+        const radius = r0 + (r1 - r0) * t;
+        floaters[i].x = cx + Math.cos(angle) * radius;
+        floaters[i].y = cy + Math.sin(angle) * radius;
+      }
+    }, easeOutCubic);
+
+    // Settle
+    await token.tween(ROTATION_SETTLE_MS * 0.3, t => {
+      for (let i = 0; i < 3; i++) {
+        floaters[i].x = targets[i].x;
+        floaters[i].y = targets[i].y;
+        floaters[i].scale = 1 + 0.15 * (1 - t);
+        floaters[i].shadow = t < 0.7;
+      }
+    }, easeOutBounce);
+  } finally {
+    for (const fp of floaters) removeFloatingPiece(fp);
+  }
+
   clearAllOverrides();
 
   // Apply the Y-rotation to the ctx.grid: rotate the 3 cells
@@ -240,6 +282,7 @@ export async function animateYRotation(ctx, clockwise, originX, originY) {
     ctx.grid[yRing[1].col][yRing[1].row] = saved[2];
     ctx.grid[yRing[2].col][yRing[2].row] = saved[0];
   }
+  return true;
 }
 
 /**
@@ -247,7 +290,7 @@ export async function animateYRotation(ctx, clockwise, originX, originY) {
  * dramatic particle burst, pearl scale-pulse.
  */
 export async function animateBlackPearlCreation(ctx, bpResults) {
-  const gen = ctx.boardGeneration;
+  const token = ctx.token;
   const { originX, originY } = getOrigin();
 
   let queuedBlackpearls = 0;
@@ -266,7 +309,7 @@ export async function animateBlackPearlCreation(ctx, bpResults) {
     }
 
     // Phase 1: Ring implodes — starflower pieces shrink toward center (400ms)
-    await tween(400, t => {
+    await token.tween(400, t => {
       for (const pos of bp.ring) {
         if (ctx.grid[pos.col]?.[pos.row]) {
           const px = hexToPixel(pos.col, pos.row, originX, originY);
@@ -280,8 +323,7 @@ export async function animateBlackPearlCreation(ctx, bpResults) {
           });
         }
       }
-    }, easeOutCubic).promise;
-    if (ctx.boardGeneration !== gen) return;
+    }, easeOutCubic);
 
     // Clear the absorbed starflowers
     for (const pos of bp.ring) {
@@ -295,7 +337,7 @@ export async function animateBlackPearlCreation(ctx, bpResults) {
     spawnCreationParticles(centerPx.x, centerPx.y, 24);
 
     // Phase 3: Pearl scale-pulse (600ms)
-    await tween(600, t => {
+    await token.tween(600, t => {
       let scale;
       if (t < 0.2) {
         scale = 1 + 0.6 * (t / 0.2);
@@ -304,54 +346,17 @@ export async function animateBlackPearlCreation(ctx, bpResults) {
         scale = 1.6 - 0.6 * settleT;
       }
       setCellOverride(bp.center.col, bp.center.row, { scale });
-    }, easeOutCubic).promise;
-    if (ctx.boardGeneration !== gen) return;
+    }, easeOutCubic);
 
     clearAllOverrides();
   }
 
-  // Gravity and refill
-  const fallMap = computeFallDistances(ctx);
-  if (fallMap.length > 0) {
-    const maxDist = Math.max(...fallMap.map(f => f.dist));
-    const fallDuration = GRAVITY_MS * maxDist;
-
-    const fallers = fallMap.map(f => {
-      const startPx = hexToPixel(f.col, f.fromRow, originX, originY);
-      const endPx = hexToPixel(f.col, f.toRow, originX, originY);
-      setCellOverride(f.col, f.fromRow, { hidden: true });
-      return {
-        fp: addFloatingPiece({
-          x: startPx.x, y: startPx.y,
-          colorIndex: f.colorIndex,
-          special: f.special,
-          bombTimer: f.bombTimer,
-          scale: 1, alpha: 1, shadow: false,
-        }),
-        startY: startPx.y,
-        endY: endPx.y,
-      };
-    });
-
-    await tween(fallDuration, t => {
-      for (const f of fallers) {
-        f.fp.y = f.startY + (f.endY - f.startY) * t;
-      }
-    }, easeOutBounce).promise;
-    if (ctx.boardGeneration !== gen) { for (const f of fallers) removeFloatingPiece(f.fp); return; }
-
-    for (const f of fallers) removeFloatingPiece(f.fp);
-    clearAllOverrides();
-  }
-
-  applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
-  const mode = getActiveGameMode();
-  const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, { starflowers: 0, blackpearls: queuedBlackpearls }, mode.isPuzzle);
-  if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
+  await animateGravity(ctx);
+  ctx.settleBoard({ starflowers: 0, blackpearls: queuedBlackpearls });
 }
 
 export async function animateGrandPoobahCreation(ctx, gpResults) {
-  const gen = ctx.boardGeneration;
+  const token = ctx.token;
   const { originX, originY } = getOrigin();
   let queuedGrandPoobahs = 0;
 
@@ -370,7 +375,7 @@ export async function animateGrandPoobahCreation(ctx, gpResults) {
     }
 
     // Phase 1: Ring implodes
-    await tween(400, t => {
+    await token.tween(400, t => {
       for (const pos of gp.ring) {
         if (ctx.grid[pos.col]?.[pos.row]) {
           const px = hexToPixel(pos.col, pos.row, originX, originY);
@@ -384,8 +389,7 @@ export async function animateGrandPoobahCreation(ctx, gpResults) {
           });
         }
       }
-    }, easeOutCubic).promise;
-    if (ctx.boardGeneration !== gen) return;
+    }, easeOutCubic);
 
     for (const pos of gp.ring) {
       if (ctx.grid[pos.col]?.[pos.row] && ctx.grid[pos.col][pos.row].special !== 'grandpoobah') {
@@ -398,7 +402,7 @@ export async function animateGrandPoobahCreation(ctx, gpResults) {
     spawnCreationParticles(centerPx.x, centerPx.y, 40);
 
     // Phase 3: Pulse
-    await tween(800, t => {
+    await token.tween(800, t => {
       let scale;
       if (t < 0.2) {
         scale = 1 + 0.8 * (t / 0.2);
@@ -407,68 +411,43 @@ export async function animateGrandPoobahCreation(ctx, gpResults) {
         scale = 1.8 - 0.8 * settleT;
       }
       setCellOverride(gp.center.col, gp.center.row, { scale });
-    }, easeOutCubic).promise;
-    if (ctx.boardGeneration !== gen) return;
+    }, easeOutCubic);
 
     clearAllOverrides();
   }
 
-  // Gravity and refill
-  const fallMap = computeFallDistances(ctx);
-  if (fallMap.length > 0) {
-    const maxDist = Math.max(...fallMap.map(f => f.dist));
-    const fallDuration = GRAVITY_MS * maxDist;
-
-    const fallers = fallMap.map(f => {
-      const startPx = hexToPixel(f.col, f.fromRow, originX, originY);
-      const endPx = hexToPixel(f.col, f.toRow, originX, originY);
-      setCellOverride(f.col, f.fromRow, { hidden: true });
-      return {
-        fp: addFloatingPiece({
-          x: startPx.x, y: startPx.y,
-          colorIndex: f.colorIndex,
-          special: f.special,
-          bombTimer: f.bombTimer,
-          scale: 1, alpha: 1, shadow: false,
-        }),
-        startY: startPx.y,
-        endY: endPx.y,
-      };
-    });
-
-    await tween(fallDuration, t => {
-      for (const f of fallers) f.fp.y = f.startY + (f.endY - f.startY) * t;
-    }, easeOutBounce).promise;
-    if (ctx.boardGeneration !== gen) { for (const f of fallers) removeFloatingPiece(f.fp); return; }
-
-    for (const f of fallers) removeFloatingPiece(f.fp);
-    clearAllOverrides();
-  }
-
-  applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
-  const mode = getActiveGameMode();
-  const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, { starflowers: 0, blackpearls: 0, grandpoobahs: queuedGrandPoobahs }, mode.isPuzzle);
-  if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
-
-  ctx.handleGameWin();
+  await animateGravity(ctx);
+  ctx.settleBoard({ starflowers: 0, blackpearls: 0, grandpoobahs: queuedGrandPoobahs });
+  // The win itself is a state transition, so the caller makes it — this
+  // function used to reach back through the context and make it here, as its
+  // last statement, and game-state.js now does it on the line after the await.
+  // Same moment in the chain, on the right side of the boundary (hecknsic#66).
 }
 
-export async function handleOverAchiever(ctx) {
-  ctx.setState('gameover');
-  stopBed(1.5);
-  playOverAchiever();
-  const combinedId = ctx.getCombinedModeId();
-  ctx.clearGameState(combinedId);
-  // Score is committed when the user confirms their name in modal-over-achiever.
-
-  document.getElementById('go-oa-score').textContent = getScore().toLocaleString();
-  document.getElementById('go-oa-combo').textContent = `x${getMaxCombo()}`;
-  prepopulateNameInputs();
-  // Non-pausing by policy (js/modal.js): the explosion tween below runs
-  // *behind* this modal and only ticks on a running loop.
-  openModal('modal-over-achiever');
-
-  // Board explosion (reuse game-over explosion aesthetic)
+/**
+ * Blow the board apart: every remaining tile becomes a floater flying away
+ * from the centre, and the grid is emptied as it goes so drawFrame stops
+ * painting the tiles the floaters now stand in for.
+ *
+ * This is the whole of what the two end-of-run sequences ever had in
+ * animations.js. The rest of what handleGameOver()/handleOverAchiever() used
+ * to do from here — the state transition, clearing the save, the lifetime
+ * stats, stopping the floor, and the modal itself — was presentation and
+ * bookkeeping wearing an animation's clothes; it lives in game-state.js and
+ * (for anything with a DOM node in it) behind that module's host, which
+ * main.js registers. hecknsic#66.
+ *
+ * The 1500 ms tween is why the end-of-run modals are non-pausing in
+ * MODAL_POLICY: the caller shows the modal and then awaits this, so a pause
+ * would park the loop that advances the tween and the await would never
+ * settle.
+ *
+ * Deliberately NOT cancellable. It runs with `state === 'gameover'`, its only
+ * board write happens before the first await, and everything after the tween
+ * is floater cleanup that must happen whatever else did — so there is nothing
+ * for a cancellation seam to protect and a throw here would skip the cleanup.
+ */
+export async function explodeBoard(ctx) {
   const { originX, originY } = getOrigin();
   const floaters = [];
 
@@ -476,6 +455,8 @@ export async function handleOverAchiever(ctx) {
     for (let r = 0; r < ctx.activeRows; r++) {
       if (ctx.grid[c][r]) {
         const px = hexToPixel(c, r, originX, originY);
+
+        // Fly away from a rough board centre.
         const dx = px.x - (originX + (ctx.activeCols * 30));
         const dy = px.y - (originY + (ctx.activeRows * 30));
         const angle = Math.atan2(dy, dx);
@@ -488,6 +469,7 @@ export async function handleOverAchiever(ctx) {
           scale: 1, alpha: 1, shadow: false
         });
 
+        // vx/vy are this animation's own; the renderer does not read them.
         floaters.push({
           fp,
           vx: Math.cos(angle) * speed,
@@ -495,6 +477,7 @@ export async function handleOverAchiever(ctx) {
           rot: (Math.random() - 0.5) * 0.5
         });
 
+        // Clear the cell immediately so drawFrame doesn't show it twice.
         ctx.grid[c][r] = null;
       }
     }
@@ -504,104 +487,13 @@ export async function handleOverAchiever(ctx) {
     for (const item of floaters) {
       item.fp.x += item.vx;
       item.fp.y += item.vy;
-      item.fp.vy += 0.5;
-      item.fp.alpha = 1 - t;
+      item.fp.vy += 0.5;      // gravity
+      item.fp.alpha = 1 - t;  // fade out
     }
   }, easeOutCubic).promise;
 
   for (const item of floaters) {
     removeFloatingPiece(item.fp);
-  }
-}
-
-export async function handleGameOver(ctx, isSessionEnd = false) {
-  ctx.setState('gameover');
-  const combinedId = ctx.getCombinedModeId();
-  ctx.clearGameState(combinedId);
-  recordGameEnd(getMaxCombo());
-  // A real game over is two events: the detonation, then the aftermath tolls a
-  // beat behind it. A peaceful chill-session end is the tolls alone — nothing
-  // exploded. The floor drops away under both.
-  stopBed(1.5);
-  playGameOver(isSessionEnd);
-  // Score is committed when the user confirms their name in modal-gameover
-  // (or already committed by btn-confirm-end before this runs, for chill).
-
-  // 1. Show Game Over Modal (only if not a peaceful chill session end)
-  const gameOverMsgEl = document.querySelector('.gameover-message');
-  if (!isSessionEnd) {
-    document.querySelector('#modal-gameover h2').textContent = 'GAME OVER';
-    document.querySelector('#modal-gameover h2').style.color = '#ff4444';
-    document.querySelector('#modal-gameover h2').style.borderColor = '#ff4444';
-    if (gameOverMsgEl) {
-      gameOverMsgEl.style.display = 'block';
-      gameOverMsgEl.textContent = '💣 A bomb exploded!';
-    }
-
-    document.getElementById('go-score').textContent = getScore().toLocaleString();
-    document.getElementById('go-combo').textContent = `x${getMaxCombo()}`;
-    prepopulateNameInputs();
-    // Non-pausing by policy (js/modal.js) — see the over-achiever note above.
-    openModal('modal-gameover');
-  }
-
-  // 2. Explode the board!
-  const { originX, originY } = getOrigin();
-  const floaters = [];
-
-  for (let c = 0; c < ctx.activeCols; c++) {
-    for (let r = 0; r < ctx.activeRows; r++) {
-      if (ctx.grid[c][r]) {
-        const px = hexToPixel(c, r, originX, originY);
-        
-        // Create a floater that flies away from center
-        const dx = px.x - (originX + (ctx.activeCols * 30)); // Rough center approx
-        const dy = px.y - (originY + (ctx.activeRows * 30));
-        const angle = Math.atan2(dy, dx);
-        const speed = 10 + Math.random() * 20;
-
-        const fp = addFloatingPiece({
-          x: px.x, y: px.y,
-          colorIndex: ctx.grid[c][r].colorIndex,
-          special: ctx.grid[c][r].special,
-          scale: 1, alpha: 1, shadow: false
-        });
-        
-        // We'll attach velocity to the floater object strictly for this animation loop
-        // (renderer doesn't use vx/vy, so we'll tween or manually update)
-        // Let's use a quick tween to blast them off
-        floaters.push({
-            fp, 
-            vx: Math.cos(angle) * speed, 
-            vy: Math.sin(angle) * speed,
-            rot: (Math.random() - 0.5) * 0.5
-        });
-        
-        // Clear ctx.grid cell immediately so drawFrame doesn't show it
-        ctx.grid[c][r] = null;
-      }
-    }
-  }
-
-  // Animate the explosion
-  // We can do a custom loop or just a tween that updates them
-  await tween(1500, t => {
-    for (const item of floaters) {
-      item.fp.x += item.vx;
-      item.fp.y += item.vy;
-      item.fp.vy += 0.5; // Gravity
-      item.fp.alpha = 1 - t; // Fade out
-      // item.fp.rotation += item.rot; // Renderer doesn't support rotation yet, but that's fine
-    }
-  }, easeOutCubic).promise;
-
-  // Cleanup
-  for (const item of floaters) {
-    removeFloatingPiece(item.fp);
-  }
-
-  if (isSessionEnd) {
-    ctx.resetGame();
   }
 }
 
@@ -611,7 +503,7 @@ export async function handleGameOver(ctx, isSessionEnd = false) {
  * @param {Array<{center, ring, ringColor}>} sfResults
  */
 export async function animateStarflowerCreation(ctx, sfResults) {
-  const gen = ctx.boardGeneration;
+  const token = ctx.token;
   // Track for puzzle goals
   for (const _ of sfResults) onStarflowerCreated();
 
@@ -629,7 +521,7 @@ export async function animateStarflowerCreation(ctx, sfResults) {
   const { originX, originY } = getOrigin();
 
   // Phase 1: Flash ring tiles bright (200ms)
-  await tween(200, t => {
+  await token.tween(200, t => {
     for (const pos of allRing) {
       if (ctx.grid[pos.col]?.[pos.row]) {
         setCellOverride(pos.col, pos.row, {
@@ -637,11 +529,10 @@ export async function animateStarflowerCreation(ctx, sfResults) {
         });
       }
     }
-  }, easeOutCubic).promise;
-  if (ctx.boardGeneration !== gen) return;
+  }, easeOutCubic);
 
   // Phase 2: Shrink and fade ring tiles (300ms)
-  await tween(300, t => {
+  await token.tween(300, t => {
     for (const pos of allRing) {
       if (ctx.grid[pos.col]?.[pos.row]) {
         setCellOverride(pos.col, pos.row, {
@@ -650,8 +541,7 @@ export async function animateStarflowerCreation(ctx, sfResults) {
         });
       }
     }
-  }, easeOutCubic).promise;
-  if (ctx.boardGeneration !== gen) return;
+  }, easeOutCubic);
 
   // Clear ring tiles
   for (const pos of allRing) {
@@ -685,7 +575,7 @@ export async function animateStarflowerCreation(ctx, sfResults) {
   }
 
   // Star piece pulse: scale up big then settle
-  await tween(500, t => {
+  await token.tween(500, t => {
     for (const center of centers) {
       let scale;
       if (t < 0.25) {
@@ -696,54 +586,16 @@ export async function animateStarflowerCreation(ctx, sfResults) {
       }
       setCellOverride(center.col, center.row, { scale });
     }
-  }, easeOutCubic).promise;
-  if (ctx.boardGeneration !== gen) return;
+  }, easeOutCubic);
 
   clearAllOverrides();
 
-  // Animated gravity
-  const fallMap = computeFallDistances(ctx);
-  if (fallMap.length > 0) {
-    const maxDist = Math.max(...fallMap.map(f => f.dist));
-    const fallDuration = GRAVITY_MS * maxDist;
-
-    const fallers = fallMap.map(f => {
-      const startPx = hexToPixel(f.col, f.fromRow, originX, originY);
-      const endPx = hexToPixel(f.col, f.toRow, originX, originY);
-      setCellOverride(f.col, f.fromRow, { hidden: true });
-      return {
-        fp: addFloatingPiece({
-          x: startPx.x, y: startPx.y,
-          colorIndex: f.colorIndex,
-          special: f.special,
-          bombTimer: f.bombTimer,
-          scale: 1, alpha: 1, shadow: false,
-        }),
-        startY: startPx.y,
-        endY: endPx.y,
-      };
-    });
-
-    await tween(fallDuration, t => {
-      for (const f of fallers) {
-        f.fp.y = f.startY + (f.endY - f.startY) * t;
-      }
-    }, easeOutBounce).promise;
-    if (ctx.boardGeneration !== gen) { for (const f of fallers) removeFloatingPiece(f.fp); return; }
-
-    for (const f of fallers) removeFloatingPiece(f.fp);
-    clearAllOverrides();
-  }
-
-  applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
-  {
-    const mode = getActiveGameMode();
-    const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, { starflowers: queuedStarflowers, blackpearls: 0 }, mode.isPuzzle);
-    if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
-  }
+  await animateGravity(ctx);
+  ctx.settleBoard({ starflowers: queuedStarflowers, blackpearls: 0 });
 }
 
-export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration) {
+export async function runCascade(ctx, initialMatches) {
+  const token = ctx.token;
   const pendingMatches = new Set(initialMatches);
   const multiplierClusters = detectMultiplierClusters(ctx.grid);
 
@@ -849,8 +701,7 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
       flashScreenOverlay(rr, gg, bb, 0.18, 35);
       spawnRingShockwave(cx, cy, 200, rr, gg, bb);
       spawnRingShockwave(cx, cy, 140, rr, gg, bb);
-      await new Promise(res => setTimeout(res, 250));
-      if (ctx.boardGeneration !== gen) return;
+      await token.delay(250);
     }
   } else if (explosionSources.length > 0) {
     let sumX = 0, sumY = 0;
@@ -866,7 +717,7 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
     spawnRingShockwave(cx, cy, 260, 255, 200, 80);
     spawnRingShockwave(cx, cy, 180, 255, 240, 160);
 
-    await tween(280, t => {
+    await token.tween(280, t => {
       for (let c = 0; c < ctx.activeCols; c++) {
         for (let r = 0; r < ctx.activeRows; r++) {
           if (!ctx.grid[c]?.[r]) continue;
@@ -879,8 +730,7 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
         }
       }
       requestRedraw();
-    }, linear).promise;
-    if (ctx.boardGeneration !== gen) return;
+    }, linear);
     clearAllOverrides();
   }
 
@@ -907,14 +757,13 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
         spawnExplosionParticles(bombPx.x, bombPx.y, 50);
         spawnRingShockwave(bombPx.x, bombPx.y, 220, 255, 60, 30);
         spawnRingShockwave(bombPx.x, bombPx.y, 130, 255, 120, 60);
-        await new Promise(res => setTimeout(res, 200));
-        if (ctx.boardGeneration !== gen) return;
+        await token.delay(200);
       }
     }
   }
 
   // ── Flash matched cells ────────────────────────────────────
-  await tween(MATCH_FLASH_MS, t => {
+  await token.tween(MATCH_FLASH_MS, t => {
     for (const key of matches) {
       const [c, r] = key.split(',').map(Number);
       if (ctx.grid[c]?.[r]) {
@@ -929,8 +778,7 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
         }
       }
     }
-  }, easeOutCubic).promise;
-  if (ctx.boardGeneration !== gen) return;
+  }, easeOutCubic);
 
   // ── Remove matched cells ───────────────────────────────────
   const points = awardMatch(matches.size, scoreBonus);
@@ -958,65 +806,70 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
   // ── Starflower detection at cleared positions ──────────────
   const sfMid = detectStarflowersAtCleared(ctx.grid, matches);
   if (sfMid.length > 0) {
+    // Both of these carry the same token, so a board replaced inside one of
+    // them throws straight through this frame — there is nothing left to check
+    // on the way back out.
     await animateStarflowerCreation(ctx, sfMid);
-    if (ctx.boardGeneration !== gen) return;
 
     const bpMid = detectBlackPearls(ctx.grid);
-    if (bpMid.length > 0) {
-      await animateBlackPearlCreation(ctx, bpMid);
-      if (ctx.boardGeneration !== gen) return;
-    }
+    if (bpMid.length > 0) await animateBlackPearlCreation(ctx, bpMid);
   }
 
-  // ── Gravity: animate pieces falling ────────────────────────
+  // ── Gravity, then commit it and fill the holes ─────────────
+  await animateGravity(ctx);
+  ctx.settleBoard();
+  requestRedraw();
+}
+
+/**
+ * Float everything that has a hole under it down to where it lands.
+ *
+ * This is the *animation* of gravity and nothing else: the board is untouched
+ * until the caller commits the move with ctx.settleBoard(), which drops the
+ * cells for real and fills the gaps. Every clear in the game ends this way, so
+ * this used to be four hand-copied blocks — one per creation animator plus the
+ * cascade — which is also why only three of the four bothered to release their
+ * floating pieces when the board was replaced mid-fall.
+ *
+ * @throws {Cancelled} if the board is replaced while the pieces are falling.
+ *         The floaters are released either way.
+ */
+async function animateGravity(ctx) {
   const fallMap = computeFallDistances(ctx);
+  if (fallMap.length === 0) return;
 
-  if (fallMap.length > 0) {
-    const maxDist = Math.max(...fallMap.map(f => f.dist));
-    const fallDuration = GRAVITY_MS * maxDist;
-    const { originX, originY } = getOrigin();
+  const { originX, originY } = getOrigin();
+  const maxDist = Math.max(...fallMap.map(f => f.dist));
+  const fallDuration = GRAVITY_MS * maxDist;
 
-    const fallers = fallMap.map(f => {
-      const startPx = hexToPixel(f.col, f.fromRow, originX, originY);
-      const endPx = hexToPixel(f.col, f.toRow, originX, originY);
-      setCellOverride(f.col, f.fromRow, { hidden: true });
-      return {
-        fp: addFloatingPiece({
-          x: startPx.x,
-          y: startPx.y,
-          colorIndex: f.colorIndex,
-          special: f.special,
-          bombTimer: f.bombTimer,
-          scale: 1,
-          alpha: 1,
-          shadow: false,
-        }),
-        startY: startPx.y,
-        endY: endPx.y,
-        x: startPx.x,
-      };
-    });
+  const fallers = fallMap.map(f => {
+    const startPx = hexToPixel(f.col, f.fromRow, originX, originY);
+    const endPx = hexToPixel(f.col, f.toRow, originX, originY);
+    setCellOverride(f.col, f.fromRow, { hidden: true });
+    return {
+      fp: addFloatingPiece({
+        x: startPx.x, y: startPx.y,
+        colorIndex: f.colorIndex,
+        special: f.special,
+        bombTimer: f.bombTimer,
+        scale: 1, alpha: 1, shadow: false,
+      }),
+      startY: startPx.y,
+      endY: endPx.y,
+    };
+  });
 
-    await tween(fallDuration, t => {
+  try {
+    await ctx.token.tween(fallDuration, t => {
       for (const f of fallers) {
         f.fp.y = f.startY + (f.endY - f.startY) * t;
       }
-    }, easeOutBounce).promise;
-    if (ctx.boardGeneration !== gen) return;
-
+    }, easeOutBounce);
+  } finally {
     for (const f of fallers) removeFloatingPiece(f.fp);
-    clearAllOverrides();
   }
 
-  // Commit gravity and fill
-  applyGravity(ctx.grid, ctx.activeCols, ctx.activeRows);
-  {
-    const mode = getActiveGameMode();
-    const filled = fillEmpty(ctx.grid, ctx.activeCols, ctx.activeRows, undefined, mode.hasBombs && ctx.bombQueued, undefined, mode.isPuzzle);
-    if (mode.hasBombs && ctx.bombQueued && filled.length > 0) ctx.setBombQueued(false);
-  }
-  requestRedraw();
-
+  clearAllOverrides();
 }
 
 /**
@@ -1046,8 +899,4 @@ function computeFallDistances(ctx) {
     }
   }
   return result;
-}
-
-export function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/js/animations.js
+++ b/js/animations.js
@@ -4,7 +4,7 @@ import {
 } from './constants.js';
 import { rotateCluster, rotateRing, applyGravity, fillEmpty } from './board.js';
 import {
-  setCellOverride, clearCellOverride, clearAllOverrides,
+  setCellOverride, clearAllOverrides,
   addFloatingPiece, removeFloatingPiece,
   spawnCreationParticles, spawnRingShockwave, requestRedraw,
   spawnColorNukeParticles, spawnExplosionParticles, spawnScorePopup, flashScreenOverlay,
@@ -13,23 +13,15 @@ import {
 import { getActiveGameMode } from './modes.js';
 import { hexToPixel, getNeighbors } from './hex-math.js';
 import { tween, easeOutCubic, easeOutBounce, linear } from './tween.js';
-import { awardMatch, advanceChain, getDisplayScore, getChainLevel, getScore, getComboCount, getMaxCombo } from './score.js';
+import { awardMatch, getChainLevel, getScore, getMaxCombo } from './score.js';
 import {
   detectStarflowersAtCleared, detectBlackPearls, detectMultiplierClusters
 } from './specials.js';
 import { onStarflowerCreated } from './puzzle-mode.js';
 import { openModal } from './modal.js';
-import { getPlayerName, recordGameEnd } from './storage.js';
+import { recordGameEnd } from './storage.js';
+import { prepopulateNameInputs } from './ui.js';
 import { playGameOver, playOverAchiever, stopBed } from './audio.js';
-
-function prepopulateNameInputs() {
-  const name = getPlayerName();
-  for (const id of ['go-name', 'gw-name', 'oa-name', 'es-name']) {
-    const el = document.getElementById(id);
-    if (el) el.value = name;
-  }
-}
-
 
 /** Animate 3-hex cluster rotation (original pop-thunk) */
 export async function animateClusterRotation(ctx, clockwise, originX, originY) {
@@ -1031,7 +1023,7 @@ export async function runCascade(ctx, initialMatches, gen = ctx.boardGeneration)
  * Compute how far each non-null cell needs to fall.
  * Returns [{ col, fromRow, toRow, dist, colorIndex }]
  */
-export function computeFallDistances(ctx) {
+function computeFallDistances(ctx) {
   const result = [];
   for (let c = 0; c < ctx.activeCols; c++) {
     if (!ctx.grid[c]) continue;

--- a/js/animations.js
+++ b/js/animations.js
@@ -18,6 +18,7 @@ import {
   detectStarflowersAtCleared, detectBlackPearls, detectMultiplierClusters
 } from './specials.js';
 import { onStarflowerCreated } from './puzzle-mode.js';
+import { openModal } from './modal.js';
 import { getPlayerName, recordGameEnd } from './storage.js';
 import { playGameOver, playOverAchiever, stopBed } from './audio.js';
 
@@ -471,7 +472,9 @@ export async function handleOverAchiever(ctx) {
   document.getElementById('go-oa-score').textContent = getScore().toLocaleString();
   document.getElementById('go-oa-combo').textContent = `x${getMaxCombo()}`;
   prepopulateNameInputs();
-  document.getElementById('modal-over-achiever').classList.remove('hidden');
+  // Non-pausing by policy (js/modal.js): the explosion tween below runs
+  // *behind* this modal and only ticks on a running loop.
+  openModal('modal-over-achiever');
 
   // Board explosion (reuse game-over explosion aesthetic)
   const { originX, originY } = getOrigin();
@@ -546,7 +549,8 @@ export async function handleGameOver(ctx, isSessionEnd = false) {
     document.getElementById('go-score').textContent = getScore().toLocaleString();
     document.getElementById('go-combo').textContent = `x${getMaxCombo()}`;
     prepopulateNameInputs();
-    document.getElementById('modal-gameover').classList.remove('hidden');
+    // Non-pausing by policy (js/modal.js) — see the over-achiever note above.
+    openModal('modal-gameover');
   }
 
   // 2. Explode the board!

--- a/js/animations.js
+++ b/js/animations.js
@@ -32,6 +32,7 @@ function prepopulateNameInputs() {
 
 /** Animate 3-hex cluster rotation (original pop-thunk) */
 export async function animateClusterRotation(ctx, clockwise, originX, originY) {
+  const gen = ctx.boardGeneration;
   const cluster = ctx.selectedCluster;
   const pixelPos = cluster.map(h => hexToPixel(h.col, h.row, originX, originY));
   const cx = (pixelPos[0].x + pixelPos[1].x + pixelPos[2].x) / 3;
@@ -88,12 +89,17 @@ export async function animateClusterRotation(ctx, clockwise, originX, originY) {
   }, easeOutBounce).promise;
 
   for (const fp of floaters) removeFloatingPiece(fp);
+  // The board can be swapped out from under an in-flight rotation (mode
+  // switch, puzzle load, restart). Rotating now would scramble three cells of
+  // the fresh board, and clearAllOverrides() would wipe the overrides it set.
+  if (ctx.boardGeneration !== gen) return;
   clearAllOverrides();
   rotateCluster(ctx.grid, cluster, clockwise);
 }
 
 /** Animate 6-hex ring rotation around flower center */
 export async function animateRingRotation(ctx, clockwise, originX, originY) {
+  const gen = ctx.boardGeneration;
   const center = ctx.flowerCenter;
   const ring = getNeighbors(center.col, center.row);
   const centerPx = hexToPixel(center.col, center.row, originX, originY);
@@ -155,12 +161,14 @@ export async function animateRingRotation(ctx, clockwise, originX, originY) {
   }, easeOutBounce).promise;
 
   for (const fp of floaters) removeFloatingPiece(fp);
+  if (ctx.boardGeneration !== gen) return; // board was replaced mid-rotation
   clearAllOverrides();
   rotateRing(ctx.grid, ring, clockwise);
 }
 
 /** Animate 3-hex Y-shape rotation around black pearl center */
 export async function animateYRotation(ctx, clockwise, originX, originY) {
+  const gen = ctx.boardGeneration;
   const center = ctx.pearlCenter;
   const nbrs = getNeighbors(center.col, center.row);
   // Y-shape uses alternating neighbors (0, 2, 4)
@@ -224,6 +232,7 @@ export async function animateYRotation(ctx, clockwise, originX, originY) {
   }, easeOutBounce).promise;
 
   for (const fp of floaters) removeFloatingPiece(fp);
+  if (ctx.boardGeneration !== gen) return; // board was replaced mid-rotation
   clearAllOverrides();
 
   // Apply the Y-rotation to the ctx.grid: rotate the 3 cells

--- a/js/audio.js
+++ b/js/audio.js
@@ -93,7 +93,7 @@ let graphMode = false;
 // AudioContext). Never a throw — these are called from the game loop, the
 // input path and the move path.
 
-export function sfx(name, opts) {
+function sfx(name, opts) {
   if (!graphMode) return;
   const a = audio();
   if (a) a.play(name, opts);

--- a/js/board.js
+++ b/js/board.js
@@ -91,15 +91,6 @@ function countRun(grid, col, row, dir, cols, rows) {
 }
 
 /**
- * Get cell at (col, row), or null if out of bounds.
- */
-export function getCell(grid, col, row) {
-  if (col < 0 || col >= grid.length) return null;
-  if (row < 0 || row >= grid[0].length) return null;
-  return grid[col][row];
-}
-
-/**
  * Swap color values of cells at positions within a cluster (rotation).
  * CW:  [0,1,2] → colors shift: 2→0, 0→1, 1→2
  * CCW: [0,1,2] → colors shift: 1→0, 2→1, 0→2

--- a/js/cancel.js
+++ b/js/cancel.js
@@ -1,0 +1,142 @@
+/**
+ * cancel.js — the mechanism that stops an async chain whose board is gone.
+ *
+ * WHAT THIS REPLACES
+ *
+ * The game's animations are long chains of awaited tweens: a rotation step is
+ * three of them, a cascade several more, and the whole thing runs for a second
+ * or two while the player can still restart, switch mode or load a puzzle.
+ * Anything that replaces the board in that window leaves a chain running with
+ * a stale grid reference, and if it commits, the player watches three cells of
+ * a brand-new board scramble themselves.
+ *
+ * The old defence was an integer — `boardGeneration`, bumped on every board
+ * replacement, captured at the top of each chain and compared after every
+ * await: `if (ctx.boardGeneration !== gen) return;`, twenty-five times across
+ * two modules. That is not a mechanism, it is a convention, and its failure
+ * mode is silence: forget one and nothing breaks until the day a player
+ * switches mode mid-rotation. Two of them were in fact missing (hecknsic#62).
+ *
+ * WHAT IT IS INSTEAD
+ *
+ * One token per board lifetime. Replacing the board cancels the outgoing
+ * token, and every chain that started on that board carries it. The check
+ * lives inside the things a chain already has to await:
+ *
+ *     await token.tween(300, t => …);   // instead of tween(…).promise
+ *     await token.delay(100);
+ *     token.guard();                    // loop heads, where nothing is awaited
+ *
+ * Each of those throws Cancelled the moment its board is gone, so the chain
+ * unwinds from wherever it happened to be, and the entry point that started it
+ * swallows that one error with catchCancelled(). A missed check is no longer
+ * possible to write: the check is not a line anyone types, it is the await.
+ *
+ * The throw is what makes the seams composable — a `return` only ends the
+ * function that wrote it, so the old idiom needed a fresh comparison in every
+ * caller up the stack, and that is exactly where they went missing.
+ *
+ * CLEANUP still belongs to the code that allocated something. A chain that
+ * throws mid-flight skips whatever came after it, so anything that must happen
+ * either way — removing floating pieces, in practice — goes in a `finally`.
+ */
+
+import { tween } from './tween.js';
+
+/**
+ * The unwind signal. Deliberately its own class: catchCancelled() must swallow
+ * this and nothing else, so a genuine bug thrown from inside an animation
+ * still reaches the console.
+ */
+export class Cancelled extends Error {
+  constructor(id) {
+    super(`board ${id} was replaced mid-animation`);
+    this.name = 'Cancelled';
+    this.boardId = id;
+  }
+}
+
+/** @param {unknown} err @returns {boolean} */
+export function isCancelled(err) {
+  return err instanceof Cancelled;
+}
+
+/**
+ * Mint a token for a board.
+ *
+ * @param {number} [id] — the board's generation number. Carried only so the
+ *        machine can still answer "which board is this?" for the save keys,
+ *        the debug hook and the tests; cancellation itself never looks at it.
+ */
+export function createCancelToken(id = 0) {
+  let cancelled = false;
+
+  const token = {
+    id,
+
+    /** @returns {boolean} */
+    get cancelled() { return cancelled; },
+
+    /** The board this token belongs to has been replaced. Idempotent. */
+    cancel() { cancelled = true; },
+
+    /** Throw if the board is gone. For loop heads and any other point that
+     *  resumes work without having awaited one of the seams below. */
+    guard() {
+      if (cancelled) throw new Cancelled(id);
+    },
+
+    /**
+     * Run a tween to completion, then guard. The one-line replacement for
+     * `await tween(…).promise; if (ctx.boardGeneration !== gen) return;`.
+     *
+     * Same arguments as js/tween.js's tween(); the handle is not returned
+     * because a caller that wants to cancel a tween early wants tween()
+     * itself, not this.
+     */
+    async tween(durationMs, onUpdate, easing) {
+      await tween(durationMs, onUpdate, easing).promise;
+      token.guard();
+    },
+
+    /** Sleep, then guard. A real timer, not a tween: it keeps running while
+     *  the frame loop is parked, which is what the pauses between cascade
+     *  steps are made of. */
+    async delay(ms) {
+      await new Promise(resolve => setTimeout(resolve, ms));
+      token.guard();
+    },
+  };
+
+  return token;
+}
+
+/** @param {unknown} value @returns {boolean} — is this a token and not, say,
+ *  a bare generation number from an older call site? */
+export function isCancelToken(value) {
+  return !!value
+    && typeof value.guard === 'function'
+    && typeof value.cancel === 'function';
+}
+
+/** A token that was born cancelled. What a caller naming a board that no
+ *  longer exists gets: the chain stops at its first seam. */
+export function cancelledToken(id = -1) {
+  const token = createCancelToken(id);
+  token.cancel();
+  return token;
+}
+
+/**
+ * The entry-point half of the mechanism: run a chain and swallow its own
+ * cancellation, which is a normal outcome and not an error. Everything else
+ * propagates.
+ *
+ * @template T @param {Promise<T>} promise @returns {Promise<T|undefined>}
+ */
+export function catchCancelled(promise) {
+  return promise.catch(err => {
+    if (isCancelled(err)) return undefined;
+    throw err;
+  });
+}

--- a/js/constants.js
+++ b/js/constants.js
@@ -3,12 +3,6 @@ export const GRID_COLS = 9;
 export const GRID_ROWS = 9;
 export const HEX_SIZE = 32;  // radius: center to vertex
 
-// Derived dimensions (flat-top hex)
-export const HEX_WIDTH  = HEX_SIZE * 2;
-export const HEX_HEIGHT = Math.sqrt(3) * HEX_SIZE;
-export const HEX_HORIZ  = HEX_WIDTH * 0.75;   // column spacing
-export const HEX_VERT   = HEX_HEIGHT;          // row spacing
-
 // ─── Colors ─────────────────────────────────────────────────────
 export const PIECE_COLORS = [
   { name: 'red',    base: '#E03030', light: '#FF6060', dark: '#901818' },
@@ -16,11 +10,6 @@ export const PIECE_COLORS = [
   { name: 'blue',   base: '#2080E0', light: '#50B0FF', dark: '#104880' },
   { name: 'green',  base: '#30A840', light: '#60D870', dark: '#186020' },
   { name: 'purple', base: '#8040C0', light: '#B070F0', dark: '#502080' },
-];
-
-// Add teal at higher levels
-export const EXTRA_COLORS = [
-  { name: 'teal', base: '#20B0B0', light: '#50E0E0', dark: '#106060' },
 ];
 
 // Bright silver chrome for starflower pieces (colorIndex = -1, unmatchable)
@@ -41,8 +30,6 @@ export const GRAND_POOBAH_COLOR = {
 // ─── UI ─────────────────────────────────────────────────────────
 export const FRAME_COLOR     = '#2A2D35';
 export const BOARD_BG_COLOR  = '#1A1D25';
-export const TEXT_COLOR       = '#D0D0D8';
-export const HIGHLIGHT_COLOR  = 'rgba(255, 255, 255, 0.85)';
 export const CLUSTER_HIGHLIGHT = 'rgba(255, 255, 200, 0.55)';
 
 // ─── Scoring ────────────────────────────────────────────────────
@@ -50,15 +37,11 @@ export const SCORE_BASE = { 3: 5, 4: 10, 5: 20 };
 export const CHAIN_MULTIPLIER_BASE = 1.5;
 
 // ─── Timing ─────────────────────────────────────────────────────
-export const FALL_SPEED = 0.008;       // cells per ms
 export const MATCH_FLASH_MS  = 500;    // flash + shrink before removal
 export const GRAVITY_MS      = 120;    // per row of falling
 export const ROTATION_POP_MS = 100;    // scale-up "pop"
 export const ROTATION_SETTLE_MS = 200; // settle back "thunk"
-export const SPAWN_DROP_MS   = 200;    // new pieces drop in
 
 // ─── Bombs ──────────────────────────────────────────────────────
 export const BOMB_INITIAL_TIMER  = 15; // moves before bomb explodes
-export const BOMB_SPAWN_INTERVAL = 2; // spawn a bomb every N moves
-export const BOMB_MIN_TIMER      = 8;  // shortest timer at high difficulty
 

--- a/js/daily-puzzle.js
+++ b/js/daily-puzzle.js
@@ -7,8 +7,8 @@
  * Goals rotate on a weekly cycle so each day has a different challenge type.
  */
 
-import { PIECE_COLORS, GRID_COLS, GRID_ROWS } from './constants.js';
-import { getPuzzleProgress, savePuzzleProgress } from './storage.js';
+import { PIECE_COLORS } from './constants.js';
+import { getPuzzleProgress } from './storage.js';
 import { makeRng } from './arcade-rng.js';
 
 // ─── Seeded RNG ─────────────────────────────────────────────────
@@ -214,10 +214,6 @@ export function generateDailyPuzzle(dateStr) {
 
 export function getDailyProgress(dateStr) {
   return getPuzzleProgress(getDailyPuzzleId(dateStr));
-}
-
-export function saveDailyProgress(dateStr, result) {
-  savePuzzleProgress(getDailyPuzzleId(dateStr), result);
 }
 
 export function getTodaysPuzzle() {

--- a/js/game-state.js
+++ b/js/game-state.js
@@ -27,9 +27,10 @@
  *      and frame.js are inert-until-registered seams built for exactly this
  *      (see their headers), and renderer/input/audio/score/storage/animations
  *      all already load under `node --test` today.
- *   2. `getAnimationContext()`, the object animations.js reads and writes the
- *      board through. Its shape is deliberately unchanged by the extraction —
- *      narrowing it is hecknsic#66.
+ *   2. `getAnimationContext()`, the object animations.js animates the board
+ *      through. Narrowed to reads plus settleBoard() by hecknsic#66: the
+ *      state transitions it used to carry (`setState`, `setBombQueued`,
+ *      `handleGameWin`, `resetGame`) are back on this side of the line.
  *   3. The host, below: the handful of effects that belong to main.js's own
  *      DOM and to main.js's own frame clock. Same pattern as
  *      `registerModalHost` / `registerFrameLoop`, and for the same reason —
@@ -45,7 +46,7 @@
  */
 
 import { GRID_COLS, GRID_ROWS, BOMB_INITIAL_TIMER } from './constants.js';
-import { createGrid, findMatchesForMode } from './board.js';
+import { createGrid, findMatchesForMode, applyGravity, fillEmpty } from './board.js';
 import {
   getIsDirty, hasActiveRendererAnimations, requestRedraw,
   setActiveGridSize, clearAllOverrides, getOrigin,
@@ -63,9 +64,12 @@ import { closeModal } from './modal.js';
 import {
   animateClusterRotation, animateRingRotation, animateYRotation,
   animateBlackPearlCreation, animateGrandPoobahCreation, animateStarflowerCreation,
-  handleOverAchiever, handleGameOver, runCascade, delay,
+  explodeBoard, runCascade,
 } from './animations.js';
 import { tween, hasActiveTweens, linear } from './tween.js';
+import {
+  createCancelToken, cancelledToken, isCancelToken, catchCancelled,
+} from './cancel.js';
 import {
   resetScore, restoreScore, advanceChain, resetChain,
   getScore, getDisplayScore, getChainLevel, getComboCount, getMaxCombo,
@@ -94,11 +98,19 @@ import { getActivePuzzle, onPuzzleMove } from './puzzle-mode.js';
 //                       main.js because it draws.
 //   onGameWin         — the win modal's presentation (name prefill, modal
 //                       open, audio). The transition itself is here.
+//   onGameOver        — same, for the end of a run: the score readout, the
+//   onOverAchiever      lifetime stats, the floor fading out, and the modal.
+//                       These two used to run from inside animations.js, which
+//                       is what put `document` in an animation module
+//                       (hecknsic#66). The transition and the explosion are
+//                       below; only the presentation goes out through here.
 
 const NOOP_HOST = {
   closeModeDropdown() {},
   resetFrameClock() {},
   onGameWin() {},
+  onGameOver() {},
+  onOverAchiever() {},
 };
 let host = NOOP_HOST;
 
@@ -123,7 +135,7 @@ export function resetGameStateForTests() {
   pearlCenter = null;
   moveCount = 0;
   bombQueued = false;
-  boardGeneration = 0;
+  boardToken = createCancelToken(0);
 }
 
 // ─── Game state ─────────────────────────────────────────────────
@@ -138,34 +150,100 @@ let flowerCenter = null;     // {col,row} if a starflower ring is selected
 let pearlCenter = null;      // {col,row} if a black pearl Y-shape is selected
 let moveCount = 0;           // total player moves (for bomb spawn timing)
 let bombQueued = false;
-let boardGeneration = 0;     // incremented on grid replacement; stale async chains bail out
+
+// ─── Board lifetime ─────────────────────────────────────────────
+//
+// One cancellation token per board (js/cancel.js). Every async chain — a
+// rotation, a cascade, a creation animation — carries the token of the board
+// it started on, and replaceBoard() below cancels it, so the chain throws at
+// its next seam instead of committing to a board that no longer exists.
+//
+// This replaces the `boardGeneration` integer that used to be compared by hand
+// after every await, twenty-five times across this module and animations.js
+// (hecknsic#66). The counter survives only as the token's id, because the
+// question "which board is this?" is still worth being able to ask.
+let boardToken = createCancelToken(0);
+
+/** Stop everything running on the outgoing board and mint the next one's
+ *  token. Called by every path that replaces the grid — and it must be called
+ *  by every such path, which is the one rule this mechanism still asks of an
+ *  author. */
+function replaceBoard() {
+  boardToken.cancel();
+  boardToken = createCancelToken(boardToken.id + 1);
+}
+
+/**
+ * Resolve whatever a caller passed as "which board" into a token.
+ *
+ * Chains inside this module pass the real thing. A bare number is the older
+ * shape — the ?debug hook and the tests name a board by its generation — and
+ * it still means exactly what it used to: this board if the number is current,
+ * a board that is already gone if it is not. Nothing means the board that is
+ * live right now, which is what a call from outside a chain means anyway.
+ */
+function asToken(t) {
+  if (isCancelToken(t)) return t;
+  if (typeof t === 'number') return t === boardToken.id ? boardToken : cancelledToken(t);
+  return boardToken;
+}
 
 // ─── Animation Context ──────────────────────────────────────────
 //
-// The handle animations.js reads and writes the board through. Its shape is
-// deliberately UNCHANGED by this extraction — the write accessors (`set grid`,
-// `setState`, `setBombQueued`) are exactly the ones hecknsic#66 removes, and
-// narrowing them here would collide with that package.
+// What an animation is allowed to see of the state machine (hecknsic#66).
+//
+// It used to hand animations.js `set grid`, `setState`, `setBombQueued`,
+// `handleGameWin`, `resetGame` and `clearGameState` — enough to drive the
+// machine from inside an animation, and it did: the win transition, the
+// game-over transition, the bomb-queue bookkeeping and the end-of-run save
+// wipe all fired from animations.js. Every one of those is a rule, and rules
+// live here.
+//
+// What is left is READ-ONLY, plus one operation:
+//
+//   grid / activeCols / activeRows — the board being animated. The array
+//     itself cannot be swapped (no setter); its cells are still written,
+//     because moving tiles around is what these functions *are*.
+//   selectedCluster / flowerCenter / pearlCenter — what the player picked.
+//   settleBoard() — gravity and refill, below. Not a write handle: the caller
+//     says "the board has finished moving", and the rule for what comes down
+//     with the refill stays on this side of the boundary.
+//
+// Animations report back by returning: the rotation animators return false
+// when the cells they were asked to turn are gone, and the caller — not the
+// animator — decides what state that means.
 
-export const getAnimationContext = () => ({
+export const getAnimationContext = (token = boardToken) => ({
   get grid() { return grid; },
-  set grid(g) { grid = g; },
   get activeCols() { return activeCols; },
   get activeRows() { return activeRows; },
-  get state() { return state; },
-  setState(s) { state = s; },
-  get boardGeneration() { return boardGeneration; },
+  get token() { return token; },
   get selectedCluster() { return selectedCluster; },
   get flowerCenter() { return flowerCenter; },
   get pearlCenter() { return pearlCenter; },
-  get moveCount() { return moveCount; },
-  get bombQueued() { return bombQueued; },
-  setBombQueued(q) { bombQueued = q; },
-  resetGame: () => resetGame(),
-  handleGameWin: () => handleGameWin(),
-  getCombinedModeId,
-  clearGameState,
+  settleBoard,
 });
+
+/**
+ * Let the board fall and refill the holes — the tail of every animation that
+ * clears cells.
+ *
+ * This is here rather than in animations.js because of the bomb queue: whether
+ * a queued bomb rides down with the refill depends on the mode's flags, and
+ * the refill is what consumes the queue. That was four hand-copied
+ * `mode.hasBombs && ctx.bombQueued` expressions in animations.js, each paired
+ * with its own `ctx.setBombQueued(false)` — the write handle #66 removes.
+ *
+ * @param {{starflowers?:number, blackpearls?:number, grandpoobahs?:number}} [extras]
+ *        specials whose centre was already special, to be re-dealt in the refill.
+ */
+function settleBoard(extras) {
+  applyGravity(grid, activeCols, activeRows);
+  const mode = getActiveGameMode();
+  const withBomb = mode.hasBombs && bombQueued;
+  const filled = fillEmpty(grid, activeCols, activeRows, undefined, withBomb, extras, mode.isPuzzle);
+  if (withBomb && filled.length > 0) bombQueued = false;
+}
 
 // ─── Accessors ──────────────────────────────────────────────────
 
@@ -182,7 +260,9 @@ export function getMoveCount() { return moveCount; }
 export function setMoveCount(n) { moveCount = n; }
 export function getBombQueued() { return bombQueued; }
 export function setBombQueued(q) { bombQueued = q; }
-export function getBoardGeneration() { return boardGeneration; }
+/** The live board's generation number — its identity, not the cancellation
+ *  mechanism. That is the token (js/cancel.js). */
+export function getBoardGeneration() { return boardToken.id; }
 export function isGamePaused() { return isPaused; }
 export function setPaused(p) { isPaused = p; }
 
@@ -236,7 +316,7 @@ export function initBoardFromSave() {
  * @param {number} cols @param {number} rows — puzzle grids may be smaller.
  */
 export function loadPuzzleBoard(puzzleGrid, cols, rows) {
-  boardGeneration++;
+  replaceBoard();
   setActiveGameMode('puzzle');
   clearAllOverrides();
   bombQueued = false;
@@ -467,7 +547,7 @@ export function processInput() {
  * it has one. Called from main.js's switchGameMode() after the HUD relayout.
  */
 export function resetBoardForNewMode() {
-  boardGeneration++;
+  replaceBoard();
   clearAllOverrides();
   bombQueued = false;
   clearSelection();
@@ -491,10 +571,11 @@ export function resetBoardForNewMode() {
   requestRedraw();
 }
 
-/** Deal a fresh board in the current mode. Reached from every "new game" button
- *  and from ctx.resetGame() at the end of the explosion sequence. */
+/** Deal a fresh board in the current mode. Reached from every "new game"
+ *  button and from handleGameOver() at the end of a chill session's
+ *  explosion. */
 export function resetGame() {
-  boardGeneration++;
+  replaceBoard();
   resetScore();
   resetChain();
   grid = createGrid();
@@ -540,21 +621,71 @@ export function handleGameWin() {
   host.onGameWin();
 }
 
+/**
+ * The end of a run: freeze the board, drop the save, hand the presentation to
+ * the host, then blow the board apart.
+ *
+ * The order is load-bearing and is exactly the order animations.js used to run
+ * it in. The modal goes up FIRST and the explosion is awaited BEHIND it —
+ * which is why 'modal-gameover' is non-pausing in MODAL_POLICY: pausing would
+ * park the loop that advances the 1500 ms tween below and the await would
+ * never settle.
+ *
+ * @param {boolean} [isSessionEnd] — true for the peaceful chill-session end
+ *        (btn-confirm-end): no game-over modal, no detonation sound, and a
+ *        fresh board dealt once the pieces have finished flying.
+ */
+export async function handleGameOver(isSessionEnd = false) {
+  state = 'gameover';
+  clearGameState(getCombinedModeId());
+  // Lifetime stats, the floor fading out, the score readout and the modal.
+  // Score itself is committed when the player confirms their name in
+  // modal-gameover (or, for chill, by btn-confirm-end before this runs).
+  host.onGameOver(isSessionEnd);
+
+  await explodeBoard(getAnimationContext());
+
+  if (isSessionEnd) resetGame();
+}
+
+/** The over-achiever end: a Grand Poobah ring, which outranks everything on
+ *  the ladder and stops the run where it stands. Same shape as
+ *  handleGameOver(), and 'modal-over-achiever' is non-pausing for the same
+ *  reason — the explosion runs behind it. */
+export async function handleOverAchiever() {
+  state = 'gameover';
+  clearGameState(getCombinedModeId());
+  host.onOverAchiever();
+
+  await explodeBoard(getAnimationContext());
+}
+
 // ─── Rotation ───────────────────────────────────────────────────
 
 /**
  * A player rotation press: spin, then look at what it produced.
+ *
+ * One of the two entry points a cancellable chain starts at, so it is one of
+ * the two places that swallow Cancelled: a board replaced mid-rotation unwinds
+ * the whole chain to here, and stopping is the correct outcome, not an error.
+ *
  * @param {boolean} clockwise
  */
-export async function animateRotation(clockwise) {
+export function animateRotation(clockwise) {
+  return catchCancelled(runRotation(clockwise));
+}
+
+/** @param {boolean} clockwise */
+async function runRotation(clockwise) {
   if (state !== 'selected') return;
   state = 'rotating';
   // One ratchet per player rotation press, not per internal step. The
   // mechanism's size follows what is actually turning: a starflower spins its
   // six-tile ring, a black pearl its Y, everything else the plain 3-cluster.
   playRotate(flowerCenter ? 'ring' : pearlCenter ? 'y' : 'cluster');
-  const gen = boardGeneration;
-  const ctx = getAnimationContext();
+  // One token for the whole press, taken from the board it started on.
+  const token = boardToken;
+  const ctx = getAnimationContext(token);
 
   const { originX, originY } = getOrigin();
 
@@ -565,15 +696,19 @@ export async function animateRotation(clockwise) {
   if (flowerCenter || pearlCenter) maxSteps = 1;
 
   for (let step = 0; step < maxSteps; step++) {
-    // 1. Animate one step
-    if (flowerCenter) {
-      await animateRingRotation(ctx, clockwise, originX, originY);
-    } else if (pearlCenter) {
-      await animateYRotation(ctx, clockwise, originX, originY);
-    } else {
-      await animateClusterRotation(ctx, clockwise, originX, originY);
-    }
-    if (boardGeneration !== gen) return; // board was replaced (e.g. restart)
+    // 1. Animate one step.
+    //
+    // `false` means the animator found a hole where its cells used to be and
+    // did nothing. It used to reach back through the context and set the state
+    // itself (`ctx.setState('idle')`); now it reports and this side decides.
+    // The loop then carries on exactly as it did before — postRotationCheck()
+    // below is what settles the state for real either way.
+    const turned = flowerCenter
+      ? await animateRingRotation(ctx, clockwise, originX, originY)
+      : pearlCenter
+        ? await animateYRotation(ctx, clockwise, originX, originY)
+        : await animateClusterRotation(ctx, clockwise, originX, originY);
+    if (turned === false) state = 'idle';
 
     // 2. Check for matches or specials
     const matches = findMatchesForMode(grid, activeCols, activeRows);
@@ -584,14 +719,14 @@ export async function animateRotation(clockwise) {
     // If we found anything significant, proceed to post-rotation logic (cascade/etc)
     // and STOP rotating.
     if (matches.size > 0 || sfResults.length > 0 || bpResults.length > 0 || gpResults.length > 0) {
-      await postRotationCheck(gen);
+      await postRotationCheck(token);
       return;
     }
   }
 
   // If we loop through all steps without a match, we are back at the start.
   // Count as a move, tick bombs, etc.
-  await postRotationCheck(gen);
+  await postRotationCheck(token);
 }
 
 /** How pressed the player is by bombs, 0..1, from the SHORTEST live fuse on the
@@ -652,14 +787,24 @@ export function nextResolution(g = grid, cols = activeCols, rows = activeRows) {
   return { kind: 'stable' };
 }
 
-/** Shared post-rotation logic: tick bombs, cascade or detect specials.
- *  @param {number} gen — boardGeneration at call time; bail out if it changes.
- *                        Always pass explicitly — do not rely on a default capture. */
-export async function postRotationCheck(gen) {
-  // Guard: callers must pass gen so stale async chains bail correctly.
-  if (gen === undefined) gen = boardGeneration;
+/**
+ * Shared post-rotation logic: tick bombs, cascade or detect specials.
+ *
+ * The other entry point that swallows Cancelled — a board replaced anywhere in
+ * the cascade unwinds to here and stops, which is the intended outcome.
+ *
+ * @param {import('./cancel.js').CancelToken|number} [token] — the board this
+ *        run belongs to. See asToken(): a generation number still works (the
+ *        ?debug hook and the tests name a board that way), and nothing at all
+ *        means the board that is live right now.
+ */
+export function postRotationCheck(token) {
+  return catchCancelled(runPostRotationCheck(asToken(token)));
+}
+
+async function runPostRotationCheck(token) {
   moveCount++;
-  const ctx = getAnimationContext();
+  const ctx = getAnimationContext(token);
 
   const mode = getActiveGameMode();
 
@@ -679,14 +824,13 @@ export async function postRotationCheck(gen) {
       // The fuse clock, with the shake. Urgency tracks the SHORTEST live fuse,
       // since that is the one about to end the game.
       playBombTick(bombUrgency());
-      await tween(250, t => {
+      await token.tween(250, t => {
         const shakeX = Math.sin(t * Math.PI * 6) * 4 * (1 - t);
         for (const b of bombCells) {
           setCellOverride(b.c, b.r, { offsetX: shakeX });
         }
         requestRedraw();
-      }, linear).promise;
-      if (boardGeneration !== gen) return;
+      }, linear);
       for (const b of bombCells) clearCellOverride(b.c, b.r);
       requestRedraw();
     }
@@ -708,27 +852,32 @@ export async function postRotationCheck(gen) {
   let isFirstStep = true;
 
   while (!boardStable) {
-    if (boardGeneration !== gen) return;
+    // The one seam in the chain with no await in front of it: the loop head
+    // resumes work on the board, so it asks before it does.
+    token.guard();
     boardStable = true;
 
     const step = nextResolution(grid, activeCols, activeRows);
 
     // Grand Poobah Ring (Over-Achiever) short-circuits the whole run.
     if (step.kind === 'poobah-ring') {
-      await handleOverAchiever(ctx);
+      await handleOverAchiever();
       return;
     }
     if (step.kind === 'stable') break;
 
     const chained = !isFirstStep;
-    if (chained) { advanceChain(); await delay(100); }
-    if (boardGeneration !== gen) return;
+    if (chained) { advanceChain(); await token.delay(100); }
     isFirstStep = false;
     state = 'cascading';
 
     if (step.kind === 'grandpoobah') {
       playSpecial('grandpoobah');
       await animateGrandPoobahCreation(ctx, step.results);
+      // Building a Grand Poobah wins the game. The animation used to make this
+      // transition itself, through the context, as its last statement; the
+      // moment in the chain is unchanged, the caller just owns it now.
+      handleGameWin();
     } else if (step.kind === 'blackpearl') {
       playSpecial('blackpearl');
       await animateBlackPearlCreation(ctx, step.results);
@@ -740,10 +889,9 @@ export async function postRotationCheck(gen) {
       // cascade steps = combo, climbing the ladder with chain depth.
       if (chained) playCombo(getChainLevel());
       else playMatch(step.results.size);
-      await runCascade(ctx, step.results, gen);
+      await runCascade(ctx, step.results);
     }
 
-    if (boardGeneration !== gen) return;
     boardStable = false;
   }
 
@@ -785,7 +933,7 @@ export async function postRotationCheck(gen) {
       }
     }
     if (exploded) {
-       handleGameOver(ctx, false);
+       handleGameOver(false);
        return;
     }
   }

--- a/js/game-state.js
+++ b/js/game-state.js
@@ -1,0 +1,792 @@
+/**
+ * game-state.js — the state machine, extracted from main.js so it can be run
+ * without a browser (hecknsic#65).
+ *
+ * States:
+ *   'idle'       – waiting for player to select a cluster
+ *   'selected'   – cluster selected, waiting for rotation or confirm
+ *   'rotating'   – pop-thunk rotation animation in progress
+ *   'cascading'  – match → flash → remove → gravity → refill → recheck
+ *   'gameover'   – input refused, board frozen behind an end-of-run modal
+ *
+ * WHY THIS MODULE EXISTS
+ *
+ * main.js was a 1,264-line script whose top level grabbed DOM nodes, installed
+ * listeners and booted the game on import, so nothing in it could be imported
+ * under `node --test`. The pure modules (board, specials, puzzles, daily) were
+ * well covered; the state machine — the band every recent regression lived in
+ * (#55 double-speed loop, #57 modal-close freeze, the parked-loop rotate
+ * buttons) — had zero coverage, because reaching it meant booting a browser.
+ *
+ * THE BOUNDARY
+ *
+ * This module contains no `document.` and no `window.` (tests/game-state.test.js
+ * holds that as a repo gate). It reaches the outside world three ways:
+ *
+ *   1. Imports of modules that are themselves node-safe by design — modal.js
+ *      and frame.js are inert-until-registered seams built for exactly this
+ *      (see their headers), and renderer/input/audio/score/storage/animations
+ *      all already load under `node --test` today.
+ *   2. `getAnimationContext()`, the object animations.js reads and writes the
+ *      board through. Its shape is deliberately unchanged by the extraction —
+ *      narrowing it is hecknsic#66.
+ *   3. The host, below: the handful of effects that belong to main.js's own
+ *      DOM and to main.js's own frame clock. Same pattern as
+ *      `registerModalHost` / `registerFrameLoop`, and for the same reason —
+ *      the module has to stay importable with nothing registered at all.
+ *
+ * IMPORT DIRECTION — one way, deliberately. main.js → game-state.js →
+ * {animations, puzzle-mode, renderer, input, audio, …}. Nothing below imports
+ * game-state.js back: animations.js is handed the context, puzzle-mode.js has
+ * its callbacks registered into it. animations.js already imports
+ * puzzle-mode.js, so a back-edge from either would close a cycle through this
+ * module — one that ESM's live bindings would let pass in node and break in
+ * the browser. Keep the arrow pointing one way.
+ */
+
+import { GRID_COLS, GRID_ROWS, BOMB_INITIAL_TIMER } from './constants.js';
+import { createGrid, findMatchesForMode } from './board.js';
+import {
+  getIsDirty, hasActiveRendererAnimations, requestRedraw,
+  setActiveGridSize, clearAllOverrides, getOrigin,
+  setCellOverride, clearCellOverride,
+} from './renderer.js';
+import {
+  getActiveGameMode, getActiveGameModeId, getCombinedModeId, setActiveGameMode,
+} from './modes.js';
+import { hexToPixel, getNeighbors, pixelToHex, findClusterAtPixel } from './hex-math.js';
+import {
+  hasPendingAction, consumeAction, getLastClickPos, setClusterCenterPx,
+} from './input.js';
+import { wakeFrameLoop } from './frame.js';
+import { closeModal } from './modal.js';
+import {
+  animateClusterRotation, animateRingRotation, animateYRotation,
+  animateBlackPearlCreation, animateGrandPoobahCreation, animateStarflowerCreation,
+  handleOverAchiever, handleGameOver, runCascade, delay,
+} from './animations.js';
+import { tween, hasActiveTweens, linear } from './tween.js';
+import {
+  resetScore, restoreScore, advanceChain, resetChain,
+  getScore, getDisplayScore, getChainLevel, getComboCount, getMaxCombo,
+  isScoreAnimating,
+} from './score.js';
+import {
+  detectStarflowers, detectBlackPearls, detectGrandPoobahs,
+  detectGrandPoobahRing, tickBombs,
+} from './specials.js';
+import { saveGameState, loadGameState, clearGameState } from './storage.js';
+import {
+  playRotate, playSelect, playMatch, playCombo, playSpecial,
+  playBombArrive, playBombTick, startBed, stopBed, setBedUrgency,
+} from './audio.js';
+import { getActivePuzzle, onPuzzleMove } from './puzzle-mode.js';
+
+// ─── Host ───────────────────────────────────────────────────────
+//
+// Same shape as js/frame.js and js/modal.js: inert until main.js registers, so
+// importing this module in node costs nothing and asserts nothing. Only three
+// hooks, and each one is here because the thing it touches is main.js's, not
+// the state machine's:
+//
+//   closeModeDropdown — the logo dropdown is a DOM node main.js owns.
+//   resetFrameClock   — `lastTime` belongs to the game loop, which stays in
+//                       main.js because it draws.
+//   onGameWin         — the win modal's presentation (name prefill, modal
+//                       open, audio). The transition itself is here.
+
+const NOOP_HOST = {
+  closeModeDropdown() {},
+  resetFrameClock() {},
+  onGameWin() {},
+};
+let host = NOOP_HOST;
+
+/** @param {Partial<typeof NOOP_HOST>} h */
+export function registerGameStateHost(h) {
+  host = {};
+  for (const key of Object.keys(NOOP_HOST)) {
+    host[key] = typeof h?.[key] === 'function' ? h[key] : NOOP_HOST[key];
+  }
+}
+
+/** Test seam: drop the host and put the machine back at boot conditions. */
+export function resetGameStateForTests() {
+  host = NOOP_HOST;
+  grid = undefined;
+  activeCols = GRID_COLS;
+  activeRows = GRID_ROWS;
+  state = 'idle';
+  isPaused = false;
+  selectedCluster = null;
+  flowerCenter = null;
+  pearlCenter = null;
+  moveCount = 0;
+  bombQueued = false;
+  boardGeneration = 0;
+}
+
+// ─── Game state ─────────────────────────────────────────────────
+
+let grid;
+let activeCols = GRID_COLS;  // may shrink for puzzle grids
+let activeRows = GRID_ROWS;
+let state = 'idle';
+let isPaused = false;
+let selectedCluster = null;
+let flowerCenter = null;     // {col,row} if a starflower ring is selected
+let pearlCenter = null;      // {col,row} if a black pearl Y-shape is selected
+let moveCount = 0;           // total player moves (for bomb spawn timing)
+let bombQueued = false;
+let boardGeneration = 0;     // incremented on grid replacement; stale async chains bail out
+
+// ─── Animation Context ──────────────────────────────────────────
+//
+// The handle animations.js reads and writes the board through. Its shape is
+// deliberately UNCHANGED by this extraction — the write accessors (`set grid`,
+// `setState`, `setBombQueued`) are exactly the ones hecknsic#66 removes, and
+// narrowing them here would collide with that package.
+
+export const getAnimationContext = () => ({
+  get grid() { return grid; },
+  set grid(g) { grid = g; },
+  get activeCols() { return activeCols; },
+  get activeRows() { return activeRows; },
+  get state() { return state; },
+  setState(s) { state = s; },
+  get boardGeneration() { return boardGeneration; },
+  get selectedCluster() { return selectedCluster; },
+  get flowerCenter() { return flowerCenter; },
+  get pearlCenter() { return pearlCenter; },
+  get moveCount() { return moveCount; },
+  get bombQueued() { return bombQueued; },
+  setBombQueued(q) { bombQueued = q; },
+  resetGame: () => resetGame(),
+  handleGameWin: () => handleGameWin(),
+  getCombinedModeId,
+  clearGameState,
+});
+
+// ─── Accessors ──────────────────────────────────────────────────
+
+export function getGrid() { return grid; }
+export function setGrid(g) { grid = g; }
+export function getActiveCols() { return activeCols; }
+export function getActiveRows() { return activeRows; }
+export function getState() { return state; }
+export function setState(s) { state = s; }
+export function getSelectedCluster() { return selectedCluster; }
+export function getFlowerCenter() { return flowerCenter; }
+export function getPearlCenter() { return pearlCenter; }
+export function getMoveCount() { return moveCount; }
+export function setMoveCount(n) { moveCount = n; }
+export function getBombQueued() { return bombQueued; }
+export function setBombQueued(q) { bombQueued = q; }
+export function getBoardGeneration() { return boardGeneration; }
+export function isGamePaused() { return isPaused; }
+export function setPaused(p) { isPaused = p; }
+
+/** Clear the whole selection — cluster and both special centres together.
+ *  They are always cleared as a set; splitting them is how a stale
+ *  flowerCenter outlives its cluster. */
+export function clearSelection() {
+  selectedCluster = null;
+  flowerCenter = null;
+  pearlCenter = null;
+}
+
+// ─── Board replacement ──────────────────────────────────────────
+
+/**
+ * Boot: adopt the saved board for the active mode, or deal a fresh one.
+ *
+ * Order-sensitive — it reads getCombinedModeId(), so it must run after
+ * loadActiveMode() and after any URL-param mode override. main.js calls it at
+ * exactly that point in its boot sequence.
+ *
+ * No generation bump: nothing is in flight at boot, and the counter is the
+ * signal to *running* async chains.
+ */
+export function initBoardFromSave() {
+  const saved = loadGameState(getCombinedModeId());
+  if (saved) {
+    grid = saved.grid;
+    restoreScore(saved);
+    moveCount = saved.moveCount || 0;
+    state = 'idle';
+  } else {
+    resetScore();
+    grid = createGrid();
+    activeCols = GRID_COLS;
+    activeRows = GRID_ROWS;
+    setActiveGridSize(GRID_COLS, GRID_ROWS);
+    state = 'idle';
+  }
+}
+
+/**
+ * Swap the board for a puzzle's fixed grid. Registered as puzzle-mode.js's
+ * onLoad callback from main.js.
+ *
+ * The generation bump is first and unconditional: a rotation or cascade still
+ * in flight on the old board has to see a changed generation at its next
+ * check, or it commits its three remembered cells onto this new grid.
+ *
+ * @param {any[][]} puzzleGrid
+ * @param {number} cols @param {number} rows — puzzle grids may be smaller.
+ */
+export function loadPuzzleBoard(puzzleGrid, cols, rows) {
+  boardGeneration++;
+  setActiveGameMode('puzzle');
+  clearAllOverrides();
+  bombQueued = false;
+  clearSelection();
+  moveCount = 0;
+  resetScore();
+  grid = puzzleGrid;
+  activeCols = cols;
+  activeRows = rows;
+  setActiveGridSize(cols, rows);
+  state = 'idle';
+  requestRedraw();
+}
+
+// ─── Predicates ─────────────────────────────────────────────────
+
+/** True while the board is mid-animation (rotating, cascading). UI should not restart. */
+export function isProcessing() {
+  return state === 'rotating' || state === 'cascading';
+}
+
+/**
+ * GAME_INTEGRATION §6d — is there any reason for another frame?
+ *
+ * Dirty-checking the *draw* was never enough: an rAF callback that decides not
+ * to paint is still an rAF callback, so the main thread woke 60x a second on a
+ * settled board and the display pipeline never reached 0 fps. This is the
+ * condition that lets the loop stop entirely.
+ *
+ * isProcessing() ('rotating' / 'cascading') is in here as a deliberate blanket:
+ * those states are driven by async chains that await sleeps between tweens, so
+ * there are moments mid-cascade with nothing dirty and no tween live. Staying
+ * awake through them is a handful of frames during motion the player asked
+ * for, and it means no cascade can strand itself waiting on a parked loop.
+ */
+export function nothingLeftToDo() {
+  return !isProcessing()
+    && !getIsDirty()
+    && !hasActiveTweens()
+    && !hasActiveRendererAnimations()
+    && !isScoreAnimating()
+    && !hasPendingAction();
+}
+
+// ─── Pause / resume ─────────────────────────────────────────────
+
+/**
+ * Come back from a modal. Every close goes through here — no longer because
+ * eleven handlers each remember to call it, but because closeModal() in
+ * js/modal.js is the only thing that closes a modal and this is its resume().
+ *
+ * Clearing isPaused is not enough on its own: a paused frame parks the loop,
+ * and a parked loop does not restart just because a flag flipped. That was
+ * already true before §6d — closing help or high-scores left the board frozen
+ * until the next resize or suspend/resume — and the more the loop parks, the
+ * more that bites. Resetting the frame clock (main.js's `lastTime`, via the
+ * host) keeps the score counter from seeing the whole time the modal was open
+ * as one delta.
+ *
+ * wakeFrameLoop() asks the gate main.js registered — `() => !isPaused` — which
+ * stays the sole authority on whether frames go back on the schedule. Nothing
+ * here calls loop.start().
+ */
+export function resumeFromPause() {
+  isPaused = false;
+  host.resetFrameClock();
+  wakeFrameLoop();
+}
+
+// ─── Selection ──────────────────────────────────────────────────
+
+/**
+ * Try to select whatever is under the cursor.
+ * Prioritizes flower rings over normal 3-hex clusters.
+ *
+ * The pixel arithmetic reads the renderer's origin and the input module's last
+ * click; neither is a DOM read, which is why this whole function moved intact.
+ * The one genuinely DOM-shaped thing it did — closing the mode dropdown when
+ * the player clicks the board — is now a host hook.
+ */
+export function trySelect() {
+  const { originX, originY } = getOrigin();
+  const clickPos = getLastClickPos();
+  if (!clickPos) {
+    clearSelection();
+    setClusterCenterPx(null, null);
+    return;
+  }
+
+  // Close dropdown if clicking on canvas
+  host.closeModeDropdown();
+
+  const hex = pixelToHex(clickPos.x, clickPos.y, originX, originY);
+
+  // Check if the clicked hex is a black pearl → Y-shape selection
+  if (hex.col >= 0 && hex.col < activeCols &&
+      hex.row >= 0 && hex.row < activeRows &&
+      grid[hex.col]?.[hex.row]?.special === 'blackpearl') {
+    // Select a Y-shape: pearl center + 3 alternating neighbors
+    const nbrs = getNeighbors(hex.col, hex.row);
+    const inBoundsNbrs = nbrs.filter(n =>
+      n.col >= 0 && n.col < activeCols && n.row >= 0 && n.row < activeRows
+    );
+    if (inBoundsNbrs.length >= 3) {
+      // Pick alternating neighbors (every other one) for Y-shape
+      // Use even-indexed neighbors: 0, 2, 4 for one Y, 1, 3, 5 for inverted
+      const yHexes = [nbrs[0], nbrs[2], nbrs[4]].filter(n =>
+        n.col >= 0 && n.col < activeCols && n.row >= 0 && n.row < activeRows
+      );
+      if (yHexes.length === 3) {
+        pearlCenter = { col: hex.col, row: hex.row };
+        flowerCenter = null;
+        selectedCluster = [{ col: hex.col, row: hex.row }, ...yHexes];
+        state = 'selected';
+        playSelect();
+        // Pearl center is the center hex pixel
+        const cp = hexToPixel(hex.col, hex.row, originX, originY);
+        setClusterCenterPx(cp.x, cp.y);
+        return;
+      }
+    }
+  }
+
+  // Check if the clicked hex is a starflower → ring selection
+  if (hex.col >= 0 && hex.col < activeCols &&
+      hex.row >= 0 && hex.row < activeRows &&
+      grid[hex.col]?.[hex.row]?.special === 'starflower') {
+    const nbrs = getNeighbors(hex.col, hex.row);
+    const allInBounds = nbrs.every(n =>
+      n.col >= 0 && n.col < activeCols && n.row >= 0 && n.row < activeRows
+    );
+    if (allInBounds) {
+      flowerCenter = { col: hex.col, row: hex.row };
+      pearlCenter = null;
+      selectedCluster = [{ col: hex.col, row: hex.row }, ...nbrs];
+      state = 'selected';
+      playSelect();
+      // Flower center pixel
+      const cp = hexToPixel(hex.col, hex.row, originX, originY);
+      setClusterCenterPx(cp.x, cp.y);
+      return;
+    }
+  }
+
+  // Normal 3-hex cluster selection
+  const cluster = findClusterAtPixel(
+    clickPos.x, clickPos.y,
+    originX, originY,
+    activeCols, activeRows
+  );
+  if (cluster) {
+    flowerCenter = null;
+    pearlCenter = null;
+    selectedCluster = cluster;
+    state = 'selected';
+    playSelect();
+    // Compute centroid of the 3 cluster hexes
+    const px = cluster.map(h => hexToPixel(h.col, h.row, originX, originY));
+    setClusterCenterPx(
+      (px[0].x + px[1].x + px[2].x) / 3,
+      (px[0].y + px[1].y + px[2].y) / 3
+    );
+  } else {
+    clearSelection();
+    setClusterCenterPx(null, null);
+  }
+}
+
+/** Same three hexes, in any order? @returns {boolean} */
+export function clustersMatch(a, b) {
+  if (!a || !b || a.length !== b.length) return false;
+  const setA = new Set(a.map(h => `${h.col},${h.row}`));
+  return b.every(h => setA.has(`${h.col},${h.row}`));
+}
+
+/**
+ * Consume the queued gesture, if the current state can use one.
+ *
+ * Called once per frame from main.js's game loop. The loop decides *when* to
+ * ask; which action means what is a rule, so it lives here.
+ *
+ * A consumed action is a genuine user gesture, which is also what unlocks the
+ * AudioContext under the browser's autoplay policy — so the ambient floor is
+ * started from here rather than at load, where it would be blocked. Both
+ * calls are idempotent and early-return once the bed is running.
+ *
+ * 'rotating' and 'cascading' deliberately do NOT consume: a gesture made
+ * mid-animation is preserved for the frame after it settles.
+ */
+export function processInput() {
+  if (state === 'idle') {
+    const action = consumeAction();
+    if (action && action.type === 'select') {
+      startBed(getActiveGameModeId());
+      trySelect();
+    }
+    return;
+  }
+
+  if (state !== 'selected') return;
+
+  const action = consumeAction();
+  if (!action) return;
+  startBed(getActiveGameModeId());
+
+  if (action.type === 'rotateCW' || action.type === 'rotateCCW') {
+    animateRotation(action.type === 'rotateCW');
+  } else if (action.type === 'select') {
+    // Click: try to select something else, or deselect
+    const prevCluster = selectedCluster;
+    trySelect();
+    if (selectedCluster === null) {
+      // Nothing to select → deselect
+      state = 'idle';
+    } else if (clustersMatch(selectedCluster, prevCluster)) {
+      // Clicked same thing → deselect
+      clearSelection();
+      state = 'idle';
+    }
+    // else: selected something new, stay in 'selected'
+  }
+}
+
+// ─── Restart / mode switch ──────────────────────────────────────
+
+/**
+ * Swap the board for the newly-selected mode's, adopting that mode's save if
+ * it has one. Called from main.js's switchGameMode() after the HUD relayout.
+ */
+export function resetBoardForNewMode() {
+  boardGeneration++;
+  clearAllOverrides();
+  bombQueued = false;
+  clearSelection();
+  const combinedId = getCombinedModeId();
+  const saved = loadGameState(combinedId);
+  if (saved) {
+    grid = saved.grid;
+    restoreScore(saved);
+    moveCount = saved.moveCount || 0;
+  } else {
+    resetScore();
+    resetChain();
+    grid = createGrid();
+    moveCount = 0;
+  }
+  activeCols = GRID_COLS;
+  activeRows = GRID_ROWS;
+  setActiveGridSize(GRID_COLS, GRID_ROWS);
+  state = 'idle';
+  closeModal('modal-gameover');
+  requestRedraw();
+}
+
+/** Deal a fresh board in the current mode. Reached from every "new game" button
+ *  and from ctx.resetGame() at the end of the explosion sequence. */
+export function resetGame() {
+  boardGeneration++;
+  resetScore();
+  resetChain();
+  grid = createGrid();
+  activeCols = GRID_COLS;
+  activeRows = GRID_ROWS;
+  setActiveGridSize(GRID_COLS, GRID_ROWS);
+  state = 'idle';
+  moveCount = 0;
+  bombQueued = false;
+  clearSelection();
+
+  // A restart is a fresh room: drop the old floor and start one at the new
+  // mode's intensity. startBed() is idempotent, so the stop matters more than
+  // the start — without it a mode switch would leave the previous bed running.
+  stopBed(0.4);
+  startBed(getActiveGameModeId());
+
+  // Ensure we are unpaused and running. closeModal() is the whole of it now:
+  // it clears the pause and calls resumeFromPause(), which wakes the loop
+  // through the gate. That used to be an open-coded `isPaused = false` plus a
+  // direct gameFrameLoop.start() here — a second way to start the loop, which
+  // is exactly what the gate exists to be the only one of.
+  closeModal('modal-gameover');
+}
+
+/** Persist the board and score under the active mode's key. */
+export function saveGame() {
+  saveGameState(getCombinedModeId(), {
+    grid,
+    moveCount,
+    score: getScore(),
+    displayScore: getDisplayScore(),
+    chainLevel: getChainLevel(),
+    comboCount: getComboCount(),
+    maxCombo: getMaxCombo(),
+  });
+}
+
+/** The win transition. Only the state change is a rule; the modal, the name
+ *  prefill and the fanfare are presentation and go through the host. */
+export function handleGameWin() {
+  state = 'gameover';
+  host.onGameWin();
+}
+
+// ─── Rotation ───────────────────────────────────────────────────
+
+/**
+ * A player rotation press: spin, then look at what it produced.
+ * @param {boolean} clockwise
+ */
+export async function animateRotation(clockwise) {
+  if (state !== 'selected') return;
+  state = 'rotating';
+  // One ratchet per player rotation press, not per internal step. The
+  // mechanism's size follows what is actually turning: a starflower spins its
+  // six-tile ring, a black pearl its Y, everything else the plain 3-cluster.
+  playRotate(flowerCenter ? 'ring' : pearlCenter ? 'y' : 'cluster');
+  const gen = boardGeneration;
+  const ctx = getAnimationContext();
+
+  const { originX, originY } = getOrigin();
+
+  // Determine max steps based on selection type
+  // Starflower ring = 6 steps for full rotation
+  // Cluster / Black Pearl (Y) = 3 steps for full rotation
+  let maxSteps = 3;
+  if (flowerCenter || pearlCenter) maxSteps = 1;
+
+  for (let step = 0; step < maxSteps; step++) {
+    // 1. Animate one step
+    if (flowerCenter) {
+      await animateRingRotation(ctx, clockwise, originX, originY);
+    } else if (pearlCenter) {
+      await animateYRotation(ctx, clockwise, originX, originY);
+    } else {
+      await animateClusterRotation(ctx, clockwise, originX, originY);
+    }
+    if (boardGeneration !== gen) return; // board was replaced (e.g. restart)
+
+    // 2. Check for matches or specials
+    const matches = findMatchesForMode(grid, activeCols, activeRows);
+    const sfResults = detectStarflowers(grid);
+    const bpResults = detectBlackPearls(grid);
+    const gpResults = detectGrandPoobahs(grid);
+
+    // If we found anything significant, proceed to post-rotation logic (cascade/etc)
+    // and STOP rotating.
+    if (matches.size > 0 || sfResults.length > 0 || bpResults.length > 0 || gpResults.length > 0) {
+      await postRotationCheck(gen);
+      return;
+    }
+  }
+
+  // If we loop through all steps without a match, we are back at the start.
+  // Count as a move, tick bombs, etc.
+  await postRotationCheck(gen);
+}
+
+/** How pressed the player is by bombs, 0..1, from the SHORTEST live fuse on the
+ *  board — that is the one that ends the game. Arcade bombs spawn at
+ *  BOMB_INITIAL_TIMER, so a fresh one sits near 0 and the last move before
+ *  detonation is 1; a puzzle bomb placed on a shorter fuse simply starts
+ *  further up the scale, which is the right reading. Returns 0 when the board
+ *  is clear, which is what silences the tension bed entirely.
+ *  @returns {number} */
+export function bombUrgency() {
+  let min = Infinity;
+  for (let c = 0; c < activeCols; c++) {
+    for (let r = 0; r < activeRows; r++) {
+      const cell = grid[c]?.[r];
+      if (cell?.special === 'bomb' && typeof cell.bombTimer === 'number') {
+        if (cell.bombTimer < min) min = cell.bombTimer;
+      }
+    }
+  }
+  if (min === Infinity) return 0;
+  const u = 1 - (min - 1) / BOMB_INITIAL_TIMER;
+  return Math.max(0, Math.min(1, u));
+}
+
+/**
+ * The cascade's priority ladder, as one decision.
+ *
+ * The order is the rule: a Grand Poobah RING (the over-achiever win) outranks
+ * everything, then Grand Poobahs, then black pearls, then starflowers, then
+ * plain matches. It matters because the formations are built out of each other
+ * — six pearls make a poobah, six starflowers make a pearl — so resolving a
+ * plain match first would clear the tiles a larger formation is standing on.
+ *
+ * Pulled out of postRotationCheck's while-loop as a pure function purely so
+ * the ladder can be asserted directly (tests/game-state.test.js). Semantics are
+ * unchanged: same detectors, same order, same short-circuiting — each detector
+ * still runs only if every higher one came back empty.
+ *
+ * @param {any[][]} g @param {number} [cols] @param {number} [rows]
+ * @returns {{kind:'poobah-ring'|'grandpoobah'|'blackpearl'|'starflower'|'match'|'stable', results?:any}}
+ */
+export function nextResolution(g = grid, cols = activeCols, rows = activeRows) {
+  const gpRing = detectGrandPoobahRing(g);
+  if (gpRing.length > 0) return { kind: 'poobah-ring', results: gpRing };
+
+  const gpResults = detectGrandPoobahs(g);
+  if (gpResults.length > 0) return { kind: 'grandpoobah', results: gpResults };
+
+  const bpResults = detectBlackPearls(g);
+  if (bpResults.length > 0) return { kind: 'blackpearl', results: bpResults };
+
+  const sfResults = detectStarflowers(g);
+  if (sfResults.length > 0) return { kind: 'starflower', results: sfResults };
+
+  const matches = findMatchesForMode(g, cols, rows);
+  if (matches.size > 0) return { kind: 'match', results: matches };
+
+  return { kind: 'stable' };
+}
+
+/** Shared post-rotation logic: tick bombs, cascade or detect specials.
+ *  @param {number} gen — boardGeneration at call time; bail out if it changes.
+ *                        Always pass explicitly — do not rely on a default capture. */
+export async function postRotationCheck(gen) {
+  // Guard: callers must pass gen so stale async chains bail correctly.
+  if (gen === undefined) gen = boardGeneration;
+  moveCount++;
+  const ctx = getAnimationContext();
+
+  const mode = getActiveGameMode();
+
+  // Tick bomb timers in any mode that has them (arcade + puzzle pre-placed bombs)
+  // Only spawn new bombs in arcade (hasBombs). Puzzle uses pre-placed bombs only.
+  if (mode.ticksBombs) {
+    tickBombs(grid);
+
+    // Animate bomb shake on tick
+    const bombCells = [];
+    for (let c = 0; c < activeCols; c++) {
+      for (let r = 0; r < activeRows; r++) {
+        if (grid[c][r]?.special === 'bomb') bombCells.push({ c, r });
+      }
+    }
+    if (bombCells.length > 0) {
+      // The fuse clock, with the shake. Urgency tracks the SHORTEST live fuse,
+      // since that is the one about to end the game.
+      playBombTick(bombUrgency());
+      await tween(250, t => {
+        const shakeX = Math.sin(t * Math.PI * 6) * 4 * (1 - t);
+        for (const b of bombCells) {
+          setCellOverride(b.c, b.r, { offsetX: shakeX });
+        }
+        requestRedraw();
+      }, linear).promise;
+      if (boardGeneration !== gen) return;
+      for (const b of bombCells) clearCellOverride(b.c, b.r);
+      requestRedraw();
+    }
+
+    // Spawn new bombs only in arcade mode
+    if (mode.hasBombs) {
+      const currentScore = getScore();
+      let dynamicInterval = 15 - Math.floor(currentScore / 5000);
+      if (dynamicInterval < 4) dynamicInterval = 4;
+      if (moveCount % dynamicInterval === 0 && !bombQueued) {
+        bombQueued = true;
+        playBombArrive(); // a bomb is about to appear on the board
+      }
+    }
+  }
+
+  // Centralized Board State Resolution Logic
+  let boardStable = false;
+  let isFirstStep = true;
+
+  while (!boardStable) {
+    if (boardGeneration !== gen) return;
+    boardStable = true;
+
+    const step = nextResolution(grid, activeCols, activeRows);
+
+    // Grand Poobah Ring (Over-Achiever) short-circuits the whole run.
+    if (step.kind === 'poobah-ring') {
+      await handleOverAchiever(ctx);
+      return;
+    }
+    if (step.kind === 'stable') break;
+
+    const chained = !isFirstStep;
+    if (chained) { advanceChain(); await delay(100); }
+    if (boardGeneration !== gen) return;
+    isFirstStep = false;
+    state = 'cascading';
+
+    if (step.kind === 'grandpoobah') {
+      playSpecial('grandpoobah');
+      await animateGrandPoobahCreation(ctx, step.results);
+    } else if (step.kind === 'blackpearl') {
+      playSpecial('blackpearl');
+      await animateBlackPearlCreation(ctx, step.results);
+    } else if (step.kind === 'starflower') {
+      playSpecial('starflower');
+      await animateStarflowerCreation(ctx, step.results);
+    } else {
+      // First clear = plain match, sized by how much glass broke; chained
+      // cascade steps = combo, climbing the ladder with chain depth.
+      if (chained) playCombo(getChainLevel());
+      else playMatch(step.results.size);
+      await runCascade(ctx, step.results, gen);
+    }
+
+    if (boardGeneration !== gen) return;
+    boardStable = false;
+  }
+
+  if (!isFirstStep) {
+    // Only deselect if a cascade or special formation occurred
+    clearSelection();
+    state = 'idle';
+  } else {
+    // Retain selection if nothing cleared
+    state = 'selected';
+  }
+
+  resetChain();
+
+  // The floor answers the board: the tension layer tracks the shortest live
+  // fuse and goes silent when there are none. Quantised + hysteresis inside,
+  // so calling it every move costs a retune only a handful of times a session.
+  setBedUrgency(bombUrgency());
+
+  // Puzzle move tracking
+  const activePuzzle = getActivePuzzle();
+  if (activePuzzle) {
+    onPuzzleMove(grid, getScore(), getChainLevel());
+    // Don't saveGame for puzzles — fixed board, no persistence needed
+  } else {
+    saveGame();
+  }
+
+  // Final check: did any un-cleared bombs expire?
+  // ticksBombs covers both arcade (hasBombs) and puzzle (pre-placed bombs)
+  if (mode.ticksBombs && mode.hasGameOver) {
+    let exploded = false;
+    for (let c = 0; c < activeCols; c++) {
+      for (let r = 0; r < activeRows; r++) {
+         if (grid[c]?.[r]?.special === 'bomb' && grid[c][r].bombTimer <= 0) {
+             exploded = true;
+             break;
+         }
+      }
+    }
+    if (exploded) {
+       handleGameOver(ctx, false);
+       return;
+    }
+  }
+}

--- a/js/hex-math.js
+++ b/js/hex-math.js
@@ -65,15 +65,6 @@ function axialToOffset(q, r) {
   return { col, row };
 }
 
-/**
- * Offset (col, row) → axial (q, r).
- */
-export function offsetToAxial(col, row) {
-  const q = col;
-  const r = row - (col - (col & 1)) / 2;
-  return { q, r };
-}
-
 // ─── Neighbors ──────────────────────────────────────────────────
 
 const NEIGHBORS_EVEN = [

--- a/js/input.js
+++ b/js/input.js
@@ -2,7 +2,7 @@
  * input.js — Mouse, touch, and keyboard input → game actions.
  */
 
-import { pixelToHex, findClusterAtPixel } from './hex-math.js';
+import { findClusterAtPixel } from './hex-math.js';
 import { getOrigin, getBoardScale, getActiveGridSize, requestRedraw } from './renderer.js';
 
 // ─── State ──────────────────────────────────────────────────────
@@ -14,7 +14,6 @@ let clusterCenterPx = null; // {x, y} pixel center of selected cluster (canvas-s
 
 export function getHoverCluster() { return hoverCluster; }
 export function getLastClickPos() { return lastClickPos; }
-export function getMousePos() { return { x: mouseX, y: mouseY }; }
 
 /**
  * Called by main.js whenever a cluster is selected/changed.

--- a/js/input.js
+++ b/js/input.js
@@ -42,9 +42,16 @@ export function hasPendingAction() { return pendingAction !== null; }
 
 /**
  * Trigger an action programmatically (e.g. from UI buttons).
+ *
+ * The redraw request is not cosmetic: since the loop parks itself on a settled
+ * board (§6d), queueing an action is only half the job — nothing consumes the
+ * queue until the loop is running again. Without this the rotate buttons did
+ * nothing until the next canvas event woke the loop, which then answered the
+ * stale gesture. Every other input path already calls this for the same reason.
  */
 export function triggerAction(type) {
   pendingAction = { type };
+  requestRedraw();
 }
 
 /**

--- a/js/main.js
+++ b/js/main.js
@@ -46,7 +46,7 @@ import {
   animateBlackPearlCreation, animateGrandPoobahCreation, animateStarflowerCreation,
   handleOverAchiever, handleGameOver, runCascade, computeFallDistances, delay
 } from './animations.js';
-import { tween, updateTweens, easeOutCubic, easeOutBounce, hasActiveTweens, linear } from './tween.js';
+import { tween, updateTweens, suspendTweenClock, easeOutCubic, easeOutBounce, hasActiveTweens, linear } from './tween.js';
 import {
   resetScore, awardMatch, advanceChain, resetChain,
   updateDisplayScore, restoreScore,
@@ -150,8 +150,11 @@ initInput(canvas);
 // dt doesn't jump after a long suspension.
 if (typeof window !== 'undefined' && window.Arcade) {
   Arcade.onSuspend(() => {
-    // Arcade.loop parks itself on suspend; this only records intent.
+    // Arcade.loop parks itself on suspend; this only records intent. The loop
+    // may be cancelled before gameLoop runs again, so parkFrameLoop() is not
+    // guaranteed to fire — stop the tween clock here too.
     isPaused = true;
+    suspendTweenClock();
   });
   Arcade.onResume(() => {
     isPaused = false;
@@ -661,6 +664,10 @@ function parkFrameLoop() {
   // the old timestamp here would hand updateDisplayScore a dt of "however long
   // the player stared at the board".
   lastTime = 0;
+  // Same reasoning one layer down. A park with tweens still in flight is the
+  // damaging case (a modal opened mid-cascade); a park on a settled board has
+  // nothing to compensate, and suspending an idle clock costs nothing.
+  suspendTweenClock();
 }
 
 // Arcade.loop passes (deltaMs, timestamp); the local dt is kept because it

--- a/js/main.js
+++ b/js/main.js
@@ -335,7 +335,9 @@ document.getElementById('game-hud-logo')?.addEventListener('click', (e) => {
 document.querySelectorAll('[data-mode]').forEach(btn => {
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
-    switchGameMode(btn.dataset.mode);
+    // Same refusal as the restart buttons: a mode switch mid-animation would
+    // replace the board out from under the rotation still running on it.
+    guardedAction(e.currentTarget, () => switchGameMode(btn.dataset.mode));
   });
 });
 
@@ -862,6 +864,10 @@ function trySelect() {
 // ─── Mode selector ──────────────────────────────────────────────
 
 async function switchGameMode(newModeId) {
+  // Backstop for the click-site guard: resetBoardForNewMode() below swaps the
+  // grid, and an in-flight rotation would land on the replacement.
+  if (isProcessing()) return;
+
   // Puzzle mode: open selector instead of switching directly
   if (newModeId === 'puzzle') {
     logoDropdown.classList.add('hidden');

--- a/js/main.js
+++ b/js/main.js
@@ -40,6 +40,7 @@ import {
   setKeyBindings, clearPendingAction, setClusterCenterPx, hasPendingAction,
 } from './input.js';
 import { registerFrameLoop, wakeFrameLoop } from './frame.js';
+import { openModal, closeModal, registerModalHost } from './modal.js';
 
 import {
   animateClusterRotation, animateRingRotation, animateYRotation,
@@ -119,7 +120,9 @@ export function isProcessing() {
 }
 
 /**
- * Come back from a modal. Every close handler goes through here.
+ * Come back from a modal. Every close goes through here — no longer because
+ * eleven handlers each remember to call it, but because closeModal() in
+ * js/modal.js is the only thing that closes a modal and this is its resume().
  *
  * Clearing isPaused is not enough on its own: a paused frame parks the loop,
  * and a parked loop does not restart just because a flag flipped. That was
@@ -133,6 +136,17 @@ function resumeFromPause() {
   lastTime = 0;
   wakeFrameLoop();
 }
+
+// Hand the pause flag to the modal seam. Every open/close in the game goes
+// through js/modal.js from here on, so the pause/resume pairing is one
+// function's problem rather than eleven call sites' — see the header there.
+// resume() is resumeFromPause() itself, which wakes the loop via wakeFrameLoop()
+// and therefore still through the gate registered below. The seam adds no
+// second way to start the loop.
+registerModalHost({
+  pause: () => { isPaused = true; },
+  resume: resumeFromPause,
+});
 
 // DEBUG: Expose internals
 window.debug = {
@@ -260,26 +274,22 @@ Arcade.onSettingsChange(applyFontScale);
 const nonGameUI = ['btn-help', 'modal-help', 'btn-close-help'];
 document.getElementById('btn-help').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = true;
-  document.getElementById('modal-help').classList.remove('hidden');
+  openModal('modal-help');
 });
 document.getElementById('btn-close-help').addEventListener('click', (e) => {
   e.stopPropagation();
-  document.getElementById('modal-help').classList.add('hidden');
-  resumeFromPause();
+  closeModal('modal-help');
 });
 
 // Scores Modal bindings
 document.getElementById('btn-scores').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = true;
   showHighScores();
-  document.getElementById('modal-scores').classList.remove('hidden');
+  openModal('modal-scores');
 });
 document.getElementById('btn-close-scores').addEventListener('click', (e) => {
   e.stopPropagation();
-  document.getElementById('modal-scores').classList.add('hidden');
-  resumeFromPause();
+  closeModal('modal-scores');
 });
 
 // Shared guard: shake a button and bail if board is mid-animation.
@@ -344,15 +354,13 @@ document.querySelectorAll('[data-mode]').forEach(btn => {
 // Settings Modal bindings
 document.getElementById('dropdown-btn-settings').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = true;
-  logoDropdown.classList.add('hidden'); // Close the menu
-  document.getElementById('modal-settings').classList.remove('hidden');
+  logoDropdown.classList.add('hidden'); // Close the menu (not a modal root)
+  openModal('modal-settings');
 });
 document.getElementById('btn-close-settings').addEventListener('click', (e) => {
   e.stopPropagation();
-  document.getElementById('modal-settings').classList.add('hidden');
   saveSettings(settings); // Persist updated bindings
-  resumeFromPause();
+  closeModal('modal-settings');
   requestRedraw();
 });
 
@@ -383,23 +391,21 @@ const endSessionModal = document.getElementById('modal-end-session');
 
 document.getElementById('dropdown-btn-end-session').addEventListener('click', (e) => {
   e.stopPropagation();
-  isPaused = true;
   logoDropdown.classList.add('hidden');
-  
+
   // Re-trigger CSS animation
   const content = endSessionModal.querySelector('.modal-content');
   content.classList.remove('shake-animation');
   void content.offsetWidth; // trigger reflow
   content.classList.add('shake-animation');
-  
+
   prepopulateNameInputs();
-  endSessionModal.classList.remove('hidden');
+  openModal('modal-end-session');
 });
 
 document.getElementById('btn-cancel-end').addEventListener('click', (e) => {
   e.stopPropagation();
-  endSessionModal.classList.add('hidden');
-  resumeFromPause();
+  closeModal('modal-end-session');
   requestRedraw();
   // allow board interactions again
 });
@@ -409,16 +415,18 @@ document.getElementById('btn-cancel-end').addEventListener('click', (e) => {
 document.getElementById('btn-continue-gamewin').addEventListener('click', (e) => {
   e.stopPropagation();
   setNameFromInput('gw-name');
-  document.getElementById('modal-gamewin').classList.add('hidden');
   state = 'idle';
-  resumeFromPause();
+  closeModal('modal-gamewin');
   requestRedraw();
 });
 
 document.getElementById('btn-newgame-gamewin').addEventListener('click', (e) => {
   e.stopPropagation();
   setNameFromInput('gw-name');
-  guardedAction(e.currentTarget, resetGame);
+  guardedAction(e.currentTarget, () => {
+    closeModal('modal-gamewin');
+    resetGame();
+  });
 });
 
 // Over-Achiever Modal binding
@@ -426,7 +434,7 @@ document.getElementById('btn-newgame-oa').addEventListener('click', (e) => {
   e.stopPropagation();
   commitScoreFromInput('oa-name', 'over-achiever');
   guardedAction(e.currentTarget, () => {
-    document.getElementById('modal-over-achiever').classList.add('hidden');
+    closeModal('modal-over-achiever');
     resetGame();
   });
 });
@@ -435,8 +443,9 @@ document.getElementById('btn-confirm-end').addEventListener('click', (e) => {
   e.stopPropagation();
   // Commit the chill-session score before the explosion sequence resets state.
   commitScoreFromInput('es-name');
-  endSessionModal.classList.add('hidden');
-  resumeFromPause(); // Must unpause so the tween game-loop can tick!
+  // closeModal() resumes: the explosion tween below only ticks on a running
+  // loop, so the close must never leave the game parked.
+  closeModal('modal-end-session');
   requestRedraw();
 
   // End session logic: trigger explosion sequence
@@ -917,7 +926,7 @@ function resetBoardForNewMode() {
   activeRows = GRID_ROWS;
   setActiveGridSize(GRID_COLS, GRID_ROWS);
   state = 'idle';
-  document.getElementById('modal-gameover').classList.add('hidden');
+  closeModal('modal-gameover');
   requestRedraw();
 }
 
@@ -976,7 +985,7 @@ function handleGameWin() {
   stopBed();
   playGameWin();
   prepopulateNameInputs();
-  document.getElementById('modal-gamewin').classList.remove('hidden');
+  openModal('modal-gamewin');
 }
 
 /** How pressed the player is by bombs, 0..1, from the SHORTEST live fuse on the
@@ -1191,16 +1200,12 @@ function resetGame() {
   stopBed(0.4);
   startBed(getActiveGameModeId());
 
-  document.getElementById('modal-gameover').classList.add('hidden');
-  
-  // Ensure we are unpaused and running
-  isPaused = false;
-  lastTime = performance.now();
-  // This line used to read "might already be running, but safe to ensure" and
-  // raw requestAnimationFrame made that false: restarting a live game stacked
-  // a second loop and orphaned the first, so tweens ran at 2x and the board
-  // drew twice per frame, permanently. loop.start() is genuinely idempotent.
-  gameFrameLoop.start();
+  // Ensure we are unpaused and running. closeModal() is the whole of it now:
+  // it clears the pause and calls resumeFromPause(), which wakes the loop
+  // through the gate. That used to be an open-coded `isPaused = false` plus a
+  // direct gameFrameLoop.start() here — a second way to start the loop, which
+  // is exactly what the gate exists to be the only one of.
+  closeModal('modal-gameover');
 }
 
 function saveGame() {

--- a/js/main.js
+++ b/js/main.js
@@ -26,7 +26,6 @@ import { registerFrameLoop } from './frame.js';
 import { openModal, closeModal, registerModalHost } from './modal.js';
 import { shakeRefusal, prepopulateNameInputs } from './ui.js';
 
-import { handleGameOver } from './animations.js';
 import { updateTweens, suspendTweenClock, hasActiveTweens } from './tween.js';
 import {
   updateDisplayScore,
@@ -36,22 +35,23 @@ import {
   addHighScore, getHighScores,
   setPlayerName,
   loadSettings, saveSettings,
-  recordModeScore, seedRecordsFromScores,
+  recordModeScore, seedRecordsFromScores, recordGameEnd,
 } from './storage.js';
 import {
-  wireUiClicks, playGameWin, stopBed,
+  wireUiClicks, playGameWin, playGameOver, playOverAchiever, stopBed,
 } from './audio.js';
 import {
   initPuzzleModeUI, showPuzzleSelector, registerPuzzleCallbacks,
   clearActivePuzzle,
 } from './puzzle-mode.js';
 import {
-  registerGameStateHost, getAnimationContext,
-  getGrid, getState, setState, getSelectedCluster, getBoardGeneration,
+  registerGameStateHost,
+  getGrid, getState, setState, getSelectedCluster,
   isGamePaused, setPaused,
   isProcessing, nothingLeftToDo, resumeFromPause, processInput,
   initBoardFromSave, loadPuzzleBoard,
   resetGame, resetBoardForNewMode, saveGame, postRotationCheck,
+  handleGameOver,
 } from './game-state.js';
 
 // ─── Bootstrap ──────────────────────────────────────────────────
@@ -72,6 +72,52 @@ registerGameStateHost({
     playGameWin();
     prepopulateNameInputs();
     openModal('modal-gamewin');
+  },
+
+  // The end-of-run presentation. All of this used to run from inside
+  // js/animations.js — the modal DOM, the lifetime stats and the audio — which
+  // is what gave an animation module a document to write to (hecknsic#66).
+  // game-state.js owns the transition and awaits the explosion; the pixels and
+  // the persistence are main.js's, so they are here.
+  //
+  // Both hooks run BEFORE the explosion tween the caller then awaits, which is
+  // the whole reason modal-gameover and modal-over-achiever are non-pausing in
+  // js/modal.js: pausing here would park the loop that tween needs.
+  onGameOver: (isSessionEnd) => {
+    recordGameEnd(getMaxCombo());
+    // A real game over is two events: the detonation, then the aftermath tolls
+    // a beat behind it. A peaceful chill-session end is the tolls alone —
+    // nothing exploded. The floor drops away under both.
+    stopBed(1.5);
+    playGameOver(isSessionEnd);
+
+    // No modal for a peaceful chill session end; the board just clears.
+    if (isSessionEnd) return;
+
+    const heading = document.querySelector('#modal-gameover h2');
+    if (heading) {
+      heading.textContent = 'GAME OVER';
+      heading.style.color = '#ff4444';
+      heading.style.borderColor = '#ff4444';
+    }
+    const messageEl = document.querySelector('.gameover-message');
+    if (messageEl) {
+      messageEl.style.display = 'block';
+      messageEl.textContent = '💣 A bomb exploded!';
+    }
+    document.getElementById('go-score').textContent = getScore().toLocaleString();
+    document.getElementById('go-combo').textContent = `x${getMaxCombo()}`;
+    prepopulateNameInputs();
+    openModal('modal-gameover');
+  },
+
+  onOverAchiever: () => {
+    stopBed(1.5);
+    playOverAchiever();
+    document.getElementById('go-oa-score').textContent = getScore().toLocaleString();
+    document.getElementById('go-oa-combo').textContent = `x${getMaxCombo()}`;
+    prepopulateNameInputs();
+    openModal('modal-over-achiever');
   },
 });
 
@@ -98,7 +144,7 @@ if (/(^|[?&#])debug\b/.test(window.location.search + window.location.hash)) {
   window.debug = {
     getGrid,
     getState,
-    runPostRotation: () => postRotationCheck(getBoardGeneration()),
+    runPostRotation: () => postRotationCheck(),
   };
 }
 
@@ -372,7 +418,7 @@ document.getElementById('btn-confirm-end').addEventListener('click', (e) => {
   requestRedraw();
 
   // End session logic: trigger explosion sequence
-  handleGameOver(getAnimationContext(), true);
+  handleGameOver(true);
 });
 
 function showHighScores() {

--- a/js/main.js
+++ b/js/main.js
@@ -1,129 +1,79 @@
 /**
- * main.js — Entry point: canvas setup, game loop, state machine.
+ * main.js — Entry point: DOM lookup, listener wiring, Arcade lifecycle, boot
+ * sequence, HUD rendering, and the frame loop that draws.
  *
- * States:
- *   'idle'       – waiting for player to select a cluster
- *   'selected'   – cluster selected, waiting for rotation or confirm
- *   'rotating'   – pop-thunk rotation animation in progress
- *   'cascading'  – match → flash → remove → gravity → refill → recheck
+ * The state machine it used to carry now lives in js/game-state.js, which has
+ * no DOM in it and so can be exercised under `node --test`
+ * (tests/game-state.test.js). What is left here is wiring: everything in this
+ * file either touches the document, subscribes to the launcher SDK, or paints.
+ * Game rules belong next door.
  */
 
 import {
-  GRID_COLS, GRID_ROWS, BOMB_INITIAL_TIMER,
-} from './constants.js';
-import { createGrid, findMatchesForMode } from './board.js';
-import {
-  initRenderer, resize, drawFrame, getOrigin,
-  setCellOverride, clearCellOverride, clearAllOverrides,
+  initRenderer, resize, drawFrame,
   requestRedraw, clearDirty, getIsDirty, hasActiveRendererAnimations,
-  setActiveGridSize, setFontScale,
+  setFontScale,
 } from './renderer.js';
 import {
   loadActiveMode, getActiveGameMode,
-  getActiveGameModeId, getCombinedModeId,
-  setActiveGameMode, getAllGameModes
+  getActiveGameModeId, setActiveGameMode, getAllGameModes
 } from './modes.js';
-import { hexToPixel, getNeighbors, pixelToHex, findClusterAtPixel } from './hex-math.js';
 import {
-  initInput, getHoverCluster, consumeAction, getLastClickPos, triggerAction,
-  setKeyBindings, clearPendingAction, setClusterCenterPx, hasPendingAction,
+  initInput, getHoverCluster, triggerAction,
+  setKeyBindings, clearPendingAction,
 } from './input.js';
-import { registerFrameLoop, wakeFrameLoop } from './frame.js';
+import { registerFrameLoop } from './frame.js';
 import { openModal, closeModal, registerModalHost } from './modal.js';
 import { shakeRefusal, prepopulateNameInputs } from './ui.js';
 
+import { handleGameOver } from './animations.js';
+import { updateTweens, suspendTweenClock, hasActiveTweens } from './tween.js';
 import {
-  animateClusterRotation, animateRingRotation, animateYRotation,
-  animateBlackPearlCreation, animateGrandPoobahCreation, animateStarflowerCreation,
-  handleOverAchiever, handleGameOver, runCascade, delay
-} from './animations.js';
-import { tween, updateTweens, suspendTweenClock, hasActiveTweens, linear } from './tween.js';
-import {
-  resetScore, advanceChain, resetChain,
-  updateDisplayScore, restoreScore,
-  getScore, getDisplayScore, getChainLevel, getComboCount, getMaxCombo, isScoreAnimating
+  updateDisplayScore,
+  getScore, getDisplayScore, getMaxCombo, isScoreAnimating
 } from './score.js';
 import {
-  detectStarflowers, detectBlackPearls, detectGrandPoobahs,
-  detectGrandPoobahRing, tickBombs,
-} from './specials.js';
-import {
-  saveGameState, loadGameState, clearGameState,
   addHighScore, getHighScores,
   setPlayerName,
   loadSettings, saveSettings,
   recordModeScore, seedRecordsFromScores,
 } from './storage.js';
 import {
-  wireUiClicks,
-  playRotate, playSelect, playMatch, playCombo, playSpecial,
-  playBombArrive, playBombTick, playGameWin,
-  startBed, stopBed, setBedUrgency,
+  wireUiClicks, playGameWin, stopBed,
 } from './audio.js';
 import {
   initPuzzleModeUI, showPuzzleSelector, registerPuzzleCallbacks,
-  clearActivePuzzle, getActivePuzzle, onPuzzleMove,
+  clearActivePuzzle,
 } from './puzzle-mode.js';
-
-
-// ─── Animation Context ───
-export const getAnimationContext = () => ({
-  get grid() { return grid; },
-  set grid(g) { grid = g; },
-  get activeCols() { return activeCols; },
-  get activeRows() { return activeRows; },
-  get state() { return state; },
-  setState(s) { state = s; },
-  get boardGeneration() { return boardGeneration; },
-  get selectedCluster() { return selectedCluster; },
-  get flowerCenter() { return flowerCenter; },
-  get pearlCenter() { return pearlCenter; },
-  get moveCount() { return moveCount; },
-  get bombQueued() { return bombQueued; },
-  setBombQueued(q) { bombQueued = q; },
-  resetGame: () => resetGame(),
-  handleGameWin: () => handleGameWin(),
-  getCombinedModeId,
-  clearGameState,
-});
-// ─── Game state ─────────────────────────────────────────────────
-let grid;
-let activeCols = GRID_COLS;  // may shrink for puzzle grids
-let activeRows = GRID_ROWS;
-let state = 'idle';  // 'idle' | 'selected' | 'rotating' | 'cascading' | 'gameover'
-let isPaused = false;
-let selectedCluster = null;
-let flowerCenter = null;     // {col,row} if a starflower ring is selected
-let pearlCenter = null;      // {col,row} if a black pearl Y-shape is selected
-let lastTime = 0;
-let moveCount = 0;           // total player moves (for bomb spawn timing)
-let bombQueued = false;
-let boardGeneration = 0;  // incremented on grid replacement; stale async chains bail out
+import {
+  registerGameStateHost, getAnimationContext,
+  getGrid, getState, setState, getSelectedCluster, getBoardGeneration,
+  isGamePaused, setPaused,
+  isProcessing, nothingLeftToDo, resumeFromPause, processInput,
+  initBoardFromSave, loadPuzzleBoard,
+  resetGame, resetBoardForNewMode, saveGame, postRotationCheck,
+} from './game-state.js';
 
 // ─── Bootstrap ──────────────────────────────────────────────────
 
-/** True while the board is mid-animation (rotating, cascading). UI should not restart. */
-function isProcessing() {
-  return state === 'rotating' || state === 'cascading';
-}
+// The frame clock. It belongs to the loop below, which is why it stays here
+// and game-state.js resets it through the host rather than owning it.
+let lastTime = 0;
 
-/**
- * Come back from a modal. Every close goes through here — no longer because
- * eleven handlers each remember to call it, but because closeModal() in
- * js/modal.js is the only thing that closes a modal and this is its resume().
- *
- * Clearing isPaused is not enough on its own: a paused frame parks the loop,
- * and a parked loop does not restart just because a flag flipped. That was
- * already true before §6d — closing help or high-scores left the board frozen
- * until the next resize or suspend/resume — and the more the loop parks, the
- * more that bites. Resetting lastTime keeps the score counter from seeing the
- * whole time the modal was open as one delta.
- */
-function resumeFromPause() {
-  isPaused = false;
-  lastTime = 0;
-  wakeFrameLoop();
-}
+registerGameStateHost({
+  closeModeDropdown: () => {
+    if (!logoDropdown.classList.contains('hidden')) {
+      logoDropdown.classList.add('hidden');
+    }
+  },
+  resetFrameClock: () => { lastTime = 0; },
+  onGameWin: () => {
+    stopBed();
+    playGameWin();
+    prepopulateNameInputs();
+    openModal('modal-gamewin');
+  },
+});
 
 // Hand the pause flag to the modal seam. Every open/close in the game goes
 // through js/modal.js from here on, so the pause/resume pairing is one
@@ -132,7 +82,7 @@ function resumeFromPause() {
 // and therefore still through the gate registered below. The seam adds no
 // second way to start the loop.
 registerModalHost({
-  pause: () => { isPaused = true; },
+  pause: () => { setPaused(true); },
   resume: resumeFromPause,
 });
 
@@ -146,9 +96,9 @@ registerModalHost({
 // launcher's iframe.
 if (/(^|[?&#])debug\b/.test(window.location.search + window.location.hash)) {
   window.debug = {
-    getGrid: () => grid,
-    getState: () => state,
-    runPostRotation: () => postRotationCheck(boardGeneration),
+    getGrid,
+    getState,
+    runPostRotation: () => postRotationCheck(getBoardGeneration()),
   };
 }
 
@@ -164,11 +114,11 @@ if (typeof window !== 'undefined' && window.Arcade) {
     // Arcade.loop parks itself on suspend; this only records intent. The loop
     // may be cancelled before gameLoop runs again, so parkFrameLoop() is not
     // guaranteed to fire — stop the tween clock here too.
-    isPaused = true;
+    setPaused(true);
     suspendTweenClock();
   });
   Arcade.onResume(() => {
-    isPaused = false;
+    setPaused(false);
     lastTime = performance.now();
     gameFrameLoop.start();
   });
@@ -180,29 +130,13 @@ if (typeof window !== 'undefined' && window.Arcade) {
 }
 
 // ─── Puzzle mode setup ───────────────────────────────────────────
-initPuzzleModeUI(() => grid, isProcessing);
+initPuzzleModeUI(getGrid, isProcessing);
 
 registerPuzzleCallbacks(
   // onLoad: replace the board with the puzzle's fixed grid
-  (puzzleGrid, cols, rows, puzzle) => {
-    boardGeneration++;
-    setActiveGameMode('puzzle');
-    clearAllOverrides();
-    bombQueued = false;
-    selectedCluster = flowerCenter = pearlCenter = null;
-    moveCount = 0;
-    resetScore();
-    grid = puzzleGrid;
-    activeCols = cols;
-    activeRows = rows;
-    setActiveGridSize(cols, rows);
-    state = 'idle';
-    requestRedraw();
-  },
+  (puzzleGrid, cols, rows, puzzle) => loadPuzzleBoard(puzzleGrid, cols, rows),
   // onEnd: freeze input when puzzle ends
-  (reason) => {
-    state = 'gameover';
-  }
+  (reason) => { setState('gameover'); }
 );
 
 // Apply settings
@@ -404,7 +338,7 @@ document.getElementById('btn-cancel-end').addEventListener('click', (e) => {
 document.getElementById('btn-continue-gamewin').addEventListener('click', (e) => {
   e.stopPropagation();
   setNameFromInput('gw-name');
-  state = 'idle';
+  setState('idle');
   closeModal('modal-gamewin');
   requestRedraw();
 });
@@ -508,7 +442,7 @@ function showHighScores() {
 }
 
 function updateControlsVisibility() {
-  if (state === 'selected' && !isPaused) {
+  if (getState() === 'selected' && !isGamePaused()) {
     controlsEl.classList.remove('hidden');
   } else {
     controlsEl.classList.add('hidden');
@@ -639,20 +573,7 @@ if (activeGameMode.id === 'chill') {
 // Initialize the unified HTML HUD for the active mode
 syncHUDForMode(activeGameMode.id);
 
-const savedState = loadGameState(getCombinedModeId());
-if (savedState) {
-  grid = savedState.grid;
-  restoreScore(savedState);
-  moveCount = savedState.moveCount || 0;
-  state = 'idle';
-} else {
-  resetScore();
-  grid = createGrid();
-  activeCols = GRID_COLS;
-  activeRows = GRID_ROWS;
-  setActiveGridSize(GRID_COLS, GRID_ROWS);
-  state = 'idle';
-}
+initBoardFromSave();
 
 // The SDK owns the frame loop. Arcade.loop cancels on suspend and re-arms on
 // resume, and start() is idempotent — it can never stack a second concurrent
@@ -661,33 +582,17 @@ const gameFrameLoop = Arcade.loop(gameLoop);
 // Hand the loop to the wake seam so renderer.requestRedraw() and tween() can
 // restart it after it parks. The gate keeps a stray redraw from reviving the
 // loop behind an open modal — that is a deliberate park, not an idle one.
-registerFrameLoop(gameFrameLoop, () => !isPaused);
+registerFrameLoop(gameFrameLoop, () => !isGamePaused());
 gameFrameLoop.start();
 
 // ─── Game loop ──────────────────────────────────────────────────
 
-/**
- * GAME_INTEGRATION §6d — is there any reason for another frame?
- *
- * Dirty-checking the *draw* was never enough: an rAF callback that decides not
- * to paint is still an rAF callback, so the main thread woke 60x a second on a
- * settled board and the display pipeline never reached 0 fps. This is the
- * condition that lets the loop stop entirely.
- *
- * isProcessing() ('rotating' / 'cascading') is in here as a deliberate blanket:
- * those states are driven by async chains that await sleeps between tweens, so
- * there are moments mid-cascade with nothing dirty and no tween live. Staying
- * awake through them is a handful of frames during motion the player asked
- * for, and it means no cascade can strand itself waiting on a parked loop.
- */
-function nothingLeftToDo() {
-  return !isProcessing()
-    && !getIsDirty()
-    && !hasActiveTweens()
-    && !hasActiveRendererAnimations()
-    && !isScoreAnimating()
-    && !hasPendingAction();
-}
+// GAME_INTEGRATION §6d — a visible-but-idle game must let the display pipeline
+// reach 0 fps, which means the loop has to stop, not just skip its draw. The
+// "is there any reason for another frame?" predicate is nothingLeftToDo(), and
+// it lives in js/game-state.js because it reads the machine's state; the two
+// halves of the arrangement — parking, and waking through js/frame.js — are
+// here, because the loop handle is here.
 
 /** Park until something wakes us. */
 function parkFrameLoop() {
@@ -707,7 +612,7 @@ function parkFrameLoop() {
 function gameLoop(_deltaMs, timestamp) {
   // Paused means paused: park the loop rather than burning a frame slot each
   // tick to do nothing. onResume/restart start() it again.
-  if (isPaused) { parkFrameLoop(); return; }
+  if (isGamePaused()) { parkFrameLoop(); return; }
 
   const dt = lastTime ? timestamp - lastTime : 16;
   lastTime = timestamp;
@@ -716,7 +621,7 @@ function gameLoop(_deltaMs, timestamp) {
   updateDisplayScore(dt);
 
   // Game over: just render, no input
-  if (state === 'gameover') {
+  if (getState() === 'gameover') {
     // Drain rather than ignore. This branch returns before the consume block,
     // so a stray keypress behind the game-over modal would sit in the queue
     // forever — and a queued gesture is one of the reasons the loop refuses to
@@ -726,7 +631,7 @@ function gameLoop(_deltaMs, timestamp) {
 
     const needsDraw = getIsDirty() || hasActiveTweens() || hasActiveRendererAnimations() || isScoreAnimating();
     if (needsDraw) {
-      drawFrame(grid, null, null);
+      drawFrame(getGrid(), null, null);
       clearDirty();
     }
     // drawGameOver(); // Handled by DOM overlay now
@@ -739,49 +644,16 @@ function gameLoop(_deltaMs, timestamp) {
     return;
   }
 
-  // Process input — only consume in states that can use it.
-  //
-  // A consumed action is a genuine user gesture, which is also what unlocks the
-  // AudioContext under the browser's autoplay policy — so the ambient floor is
-  // started from here rather than at load, where it would be blocked. Both
-  // calls are idempotent and early-return once the bed is running.
-  if (state === 'idle') {
-    const action = consumeAction();
-    if (action && action.type === 'select') {
-      startBed(getActiveGameModeId());
-      trySelect();
-    }
-  } else if (state === 'selected') {
-    const action = consumeAction();
-    if (action) {
-      startBed(getActiveGameModeId());
-      if (action.type === 'rotateCW' || action.type === 'rotateCCW') {
-        animateRotation(action.type === 'rotateCW');
-      } else if (action.type === 'select') {
-        // Click: try to select something else, or deselect
-        const prevCluster = selectedCluster;
-        trySelect();
-        if (selectedCluster === null) {
-          // Nothing to select → deselect
-          state = 'idle';
-        } else if (clustersMatch(selectedCluster, prevCluster)) {
-          // Clicked same thing → deselect
-          selectedCluster = null;
-          flowerCenter = null;
-          pearlCenter = null;
-          state = 'idle';
-        }
-        // else: selected something new, stay in 'selected'
-      }
-    }
-  }
-  // 'rotating' and 'cascading': input is NOT consumed (preserved for later)
+  // Consume the queued gesture and apply it to the machine. The rules live in
+  // js/game-state.js; the loop only decides *when* to ask.
+  processInput();
 
   // Draw
   const needsDraw = getIsDirty() || hasActiveTweens() || hasActiveRendererAnimations() || isScoreAnimating();
   if (needsDraw) {
-    const hover = (state === 'idle') ? getHoverCluster() : null;
-    drawFrame(grid, hover, (state === 'selected' ? selectedCluster : null));
+    const st = getState();
+    const hover = (st === 'idle') ? getHoverCluster() : null;
+    drawFrame(getGrid(), hover, (st === 'selected' ? getSelectedCluster() : null));
     clearDirty();
   }
 
@@ -791,104 +663,6 @@ function gameLoop(_deltaMs, timestamp) {
   // Settled board, no pending gesture, nothing animating: 0 fps until the
   // player does something. requestRedraw() / tween() bring us back.
   if (nothingLeftToDo()) parkFrameLoop();
-}
-
-/**
- * Try to select whatever is under the cursor.
- * Prioritizes flower rings over normal 3-hex clusters.
- */
-function trySelect() {
-  const { originX, originY } = getOrigin();
-  const clickPos = getLastClickPos();
-  if (!clickPos) {
-    selectedCluster = null;
-    flowerCenter = null;
-    pearlCenter = null;
-    setClusterCenterPx(null, null);
-    return;
-  }
-
-  // Close dropdown if clicking on canvas
-  if (!logoDropdown.classList.contains('hidden')) {
-    logoDropdown.classList.add('hidden');
-  }
-
-  const hex = pixelToHex(clickPos.x, clickPos.y, originX, originY);
-
-  // Check if the clicked hex is a black pearl → Y-shape selection
-  if (hex.col >= 0 && hex.col < activeCols &&
-      hex.row >= 0 && hex.row < activeRows &&
-      grid[hex.col]?.[hex.row]?.special === 'blackpearl') {
-    // Select a Y-shape: pearl center + 3 alternating neighbors
-    const nbrs = getNeighbors(hex.col, hex.row);
-    const inBoundsNbrs = nbrs.filter(n =>
-      n.col >= 0 && n.col < activeCols && n.row >= 0 && n.row < activeRows
-    );
-    if (inBoundsNbrs.length >= 3) {
-      // Pick alternating neighbors (every other one) for Y-shape
-      // Use even-indexed neighbors: 0, 2, 4 for one Y, 1, 3, 5 for inverted
-      const yHexes = [nbrs[0], nbrs[2], nbrs[4]].filter(n =>
-        n.col >= 0 && n.col < activeCols && n.row >= 0 && n.row < activeRows
-      );
-      if (yHexes.length === 3) {
-        pearlCenter = { col: hex.col, row: hex.row };
-        flowerCenter = null;
-        selectedCluster = [{ col: hex.col, row: hex.row }, ...yHexes];
-        state = 'selected';
-        playSelect();
-        // Pearl center is the center hex pixel
-        const cp = hexToPixel(hex.col, hex.row, originX, originY);
-        setClusterCenterPx(cp.x, cp.y);
-        return;
-      }
-    }
-  }
-
-  // Check if the clicked hex is a starflower → ring selection
-  if (hex.col >= 0 && hex.col < activeCols &&
-      hex.row >= 0 && hex.row < activeRows &&
-      grid[hex.col]?.[hex.row]?.special === 'starflower') {
-    const nbrs = getNeighbors(hex.col, hex.row);
-    const allInBounds = nbrs.every(n =>
-      n.col >= 0 && n.col < activeCols && n.row >= 0 && n.row < activeRows
-    );
-    if (allInBounds) {
-      flowerCenter = { col: hex.col, row: hex.row };
-      pearlCenter = null;
-      selectedCluster = [{ col: hex.col, row: hex.row }, ...nbrs];
-      state = 'selected';
-      playSelect();
-      // Flower center pixel
-      const cp = hexToPixel(hex.col, hex.row, originX, originY);
-      setClusterCenterPx(cp.x, cp.y);
-      return;
-    }
-  }
-
-  // Normal 3-hex cluster selection
-  const cluster = findClusterAtPixel(
-    clickPos.x, clickPos.y,
-    originX, originY,
-    activeCols, activeRows
-  );
-  if (cluster) {
-    flowerCenter = null;
-    pearlCenter = null;
-    selectedCluster = cluster;
-    state = 'selected';
-    playSelect();
-    // Compute centroid of the 3 cluster hexes
-    const px = cluster.map(h => hexToPixel(h.col, h.row, originX, originY));
-    setClusterCenterPx(
-      (px[0].x + px[1].x + px[2].x) / 3,
-      (px[0].y + px[1].y + px[2].y) / 3
-    );
-  } else {
-    selectedCluster = null;
-    flowerCenter = null;
-    pearlCenter = null;
-    setClusterCenterPx(null, null);
-  }
 }
 
 // ─── Mode selector ──────────────────────────────────────────────
@@ -926,342 +700,6 @@ async function switchGameMode(newModeId) {
 
 // switchMatchMode removed — line variant deprecated, see tag feature/line-match-mode
 
-function resetBoardForNewMode() {
-  boardGeneration++;
-  clearAllOverrides();
-  bombQueued = false;
-  selectedCluster = flowerCenter = pearlCenter = null;
-  const combinedId = getCombinedModeId();
-  const saved = loadGameState(combinedId);
-  if (saved) {
-    grid = saved.grid;
-    restoreScore(saved);
-    moveCount = saved.moveCount || 0;
-  } else {
-    resetScore();
-    resetChain();
-    grid = createGrid();
-    moveCount = 0;
-  }
-  activeCols = GRID_COLS;
-  activeRows = GRID_ROWS;
-  setActiveGridSize(GRID_COLS, GRID_ROWS);
-  state = 'idle';
-  closeModal('modal-gameover');
-  requestRedraw();
-}
-
-// ─── Rotation animation ────────────────────────────────────────
-
-async function animateRotation(clockwise) {
-  if (state !== 'selected') return;
-  state = 'rotating';
-  // One ratchet per player rotation press, not per internal step. The
-  // mechanism's size follows what is actually turning: a starflower spins its
-  // six-tile ring, a black pearl its Y, everything else the plain 3-cluster.
-  playRotate(flowerCenter ? 'ring' : pearlCenter ? 'y' : 'cluster');
-  const gen = boardGeneration;
-  const ctx = getAnimationContext();
-
-  const { originX, originY } = getOrigin();
-
-  // Determine max steps based on selection type
-  // Starflower ring = 6 steps for full rotation
-  // Cluster / Black Pearl (Y) = 3 steps for full rotation
-  let maxSteps = 3;
-  if (flowerCenter || pearlCenter) maxSteps = 1;
-
-  for (let step = 0; step < maxSteps; step++) {
-    // 1. Animate one step
-    if (flowerCenter) {
-      await animateRingRotation(ctx, clockwise, originX, originY);
-    } else if (pearlCenter) {
-      await animateYRotation(ctx, clockwise, originX, originY);
-    } else {
-      await animateClusterRotation(ctx, clockwise, originX, originY);
-    }
-    if (boardGeneration !== gen) return; // board was replaced (e.g. restart)
-
-    // 2. Check for matches or specials
-    const matches = findMatchesForMode(grid, activeCols, activeRows);
-    const sfResults = detectStarflowers(grid);
-    const bpResults = detectBlackPearls(grid);
-    const gpResults = detectGrandPoobahs(grid);
-
-    // If we found anything significant, proceed to post-rotation logic (cascade/etc)
-    // and STOP rotating.
-    if (matches.size > 0 || sfResults.length > 0 || bpResults.length > 0 || gpResults.length > 0) {
-      await postRotationCheck(gen);
-      return;
-    }
-  }
-
-  // If we loop through all steps without a match, we are back at the start.
-  // Count as a move, tick bombs, etc.
-  await postRotationCheck(gen);
-}
-
-function handleGameWin() {
-  state = 'gameover';
-  stopBed();
-  playGameWin();
-  prepopulateNameInputs();
-  openModal('modal-gamewin');
-}
-
-/** How pressed the player is by bombs, 0..1, from the SHORTEST live fuse on the
- *  board — that is the one that ends the game. Arcade bombs spawn at
- *  BOMB_INITIAL_TIMER, so a fresh one sits near 0 and the last move before
- *  detonation is 1; a puzzle bomb placed on a shorter fuse simply starts
- *  further up the scale, which is the right reading. Returns 0 when the board
- *  is clear, which is what silences the tension bed entirely.
- *  @returns {number} */
-function bombUrgency() {
-  let min = Infinity;
-  for (let c = 0; c < activeCols; c++) {
-    for (let r = 0; r < activeRows; r++) {
-      const cell = grid[c]?.[r];
-      if (cell?.special === 'bomb' && typeof cell.bombTimer === 'number') {
-        if (cell.bombTimer < min) min = cell.bombTimer;
-      }
-    }
-  }
-  if (min === Infinity) return 0;
-  const u = 1 - (min - 1) / BOMB_INITIAL_TIMER;
-  return Math.max(0, Math.min(1, u));
-}
-
-/** Shared post-rotation logic: tick bombs, cascade or detect specials.
- *  @param {number} gen — boardGeneration at call time; bail out if it changes.
- *                        Always pass explicitly — do not rely on a default capture. */
-async function postRotationCheck(gen) {
-  // Guard: callers must pass gen so stale async chains bail correctly.
-  if (gen === undefined) gen = boardGeneration;
-  moveCount++;
-  const ctx = getAnimationContext();
-
-  const mode = getActiveGameMode();
-
-  // Tick bomb timers in any mode that has them (arcade + puzzle pre-placed bombs)
-  // Only spawn new bombs in arcade (hasBombs). Puzzle uses pre-placed bombs only.
-  if (mode.ticksBombs) {
-    tickBombs(grid);
-
-    // Animate bomb shake on tick
-    const bombCells = [];
-    for (let c = 0; c < activeCols; c++) {
-      for (let r = 0; r < activeRows; r++) {
-        if (grid[c][r]?.special === 'bomb') bombCells.push({ c, r });
-      }
-    }
-    if (bombCells.length > 0) {
-      // The fuse clock, with the shake. Urgency tracks the SHORTEST live fuse,
-      // since that is the one about to end the game.
-      playBombTick(bombUrgency());
-      await tween(250, t => {
-        const shakeX = Math.sin(t * Math.PI * 6) * 4 * (1 - t);
-        for (const b of bombCells) {
-          setCellOverride(b.c, b.r, { offsetX: shakeX });
-        }
-        requestRedraw();
-      }, linear).promise;
-      if (boardGeneration !== gen) return;
-      for (const b of bombCells) clearCellOverride(b.c, b.r);
-      requestRedraw();
-    }
-
-    // Spawn new bombs only in arcade mode
-    if (mode.hasBombs) {
-      const currentScore = getScore();
-      let dynamicInterval = 15 - Math.floor(currentScore / 5000);
-      if (dynamicInterval < 4) dynamicInterval = 4;
-      if (moveCount % dynamicInterval === 0 && !bombQueued) {
-        bombQueued = true;
-        playBombArrive(); // a bomb is about to appear on the board
-      }
-    }
-  }
-
-  // Centralized Board State Resolution Logic
-  let boardStable = false;
-  let isFirstStep = true;
-
-  while (!boardStable) {
-    if (boardGeneration !== gen) return;
-    boardStable = true;
-
-    // Check for Grand Poobah Ring (Over-Achiever) before anything else
-    const gpRing = detectGrandPoobahRing(grid);
-    if (gpRing.length > 0) {
-      await handleOverAchiever(ctx);
-      return;
-    }
-
-    const gpResults = detectGrandPoobahs(grid);
-    if (gpResults.length > 0) {
-      if (!isFirstStep) { advanceChain(); await delay(100); }
-      if (boardGeneration !== gen) return;
-      isFirstStep = false;
-      state = 'cascading';
-      playSpecial('grandpoobah');
-      await animateGrandPoobahCreation(ctx, gpResults);
-      if (boardGeneration !== gen) return;
-      boardStable = false;
-      continue;
-    }
-
-    const bpResults = detectBlackPearls(grid);
-    if (bpResults.length > 0) {
-      if (!isFirstStep) { advanceChain(); await delay(100); }
-      if (boardGeneration !== gen) return;
-      isFirstStep = false;
-      state = 'cascading';
-      playSpecial('blackpearl');
-      await animateBlackPearlCreation(ctx, bpResults);
-      if (boardGeneration !== gen) return;
-      boardStable = false;
-      continue;
-    }
-
-    const sfResults = detectStarflowers(grid);
-    if (sfResults.length > 0) {
-      if (!isFirstStep) { advanceChain(); await delay(100); }
-      if (boardGeneration !== gen) return;
-      isFirstStep = false;
-      state = 'cascading';
-      playSpecial('starflower');
-      await animateStarflowerCreation(ctx, sfResults);
-      if (boardGeneration !== gen) return;
-      boardStable = false;
-      continue;
-    }
-
-    const matches = findMatchesForMode(grid, activeCols, activeRows);
-    if (matches.size > 0) {
-      const chained = !isFirstStep;
-      if (chained) { advanceChain(); await delay(100); }
-      if (boardGeneration !== gen) return;
-      isFirstStep = false;
-      state = 'cascading';
-      // First clear = plain match, sized by how much glass broke; chained
-      // cascade steps = combo, climbing the ladder with chain depth.
-      if (chained) playCombo(getChainLevel());
-      else playMatch(matches.size);
-      await runCascade(ctx, matches, gen);
-      if (boardGeneration !== gen) return;
-      boardStable = false;
-      continue;
-    }
-  }
-
-  if (!isFirstStep) {
-    // Only deselect if a cascade or special formation occurred
-    selectedCluster = null;
-    flowerCenter = null;
-    pearlCenter = null;
-    state = 'idle';
-  } else {
-    // Retain selection if nothing cleared
-    state = 'selected';
-  }
-
-  resetChain();
-
-  // The floor answers the board: the tension layer tracks the shortest live
-  // fuse and goes silent when there are none. Quantised + hysteresis inside,
-  // so calling it every move costs a retune only a handful of times a session.
-  setBedUrgency(bombUrgency());
-
-  // Puzzle move tracking
-  const activePuzzle = getActivePuzzle();
-  if (activePuzzle) {
-    onPuzzleMove(grid, getScore(), getChainLevel());
-    // Don't saveGame for puzzles — fixed board, no persistence needed
-  } else {
-    saveGame();
-  }
-
-  // Final check: did any un-cleared bombs expire?
-  // ticksBombs covers both arcade (hasBombs) and puzzle (pre-placed bombs)
-  if (mode.ticksBombs && mode.hasGameOver) {
-    let exploded = false;
-    for (let c = 0; c < activeCols; c++) {
-      for (let r = 0; r < activeRows; r++) {
-         if (grid[c]?.[r]?.special === 'bomb' && grid[c][r].bombTimer <= 0) {
-             exploded = true;
-             break;
-         }
-      }
-    }
-    if (exploded) {
-       handleGameOver(ctx, false);
-       return;
-    }
-  }
-}
-
-function resetGame() {
-  boardGeneration++;
-  resetScore();
-  resetChain();
-  grid = createGrid();
-  activeCols = GRID_COLS;
-  activeRows = GRID_ROWS;
-  setActiveGridSize(GRID_COLS, GRID_ROWS);
-  state = 'idle';
-  moveCount = 0;
-  bombQueued = false;
-  selectedCluster = null;
-  flowerCenter = null;
-  pearlCenter = null;
-
-  // A restart is a fresh room: drop the old floor and start one at the new
-  // mode's intensity. startBed() is idempotent, so the stop matters more than
-  // the start — without it a mode switch would leave the previous bed running.
-  stopBed(0.4);
-  startBed(getActiveGameModeId());
-
-  // Ensure we are unpaused and running. closeModal() is the whole of it now:
-  // it clears the pause and calls resumeFromPause(), which wakes the loop
-  // through the gate. That used to be an open-coded `isPaused = false` plus a
-  // direct gameFrameLoop.start() here — a second way to start the loop, which
-  // is exactly what the gate exists to be the only one of.
-  closeModal('modal-gameover');
-}
-
-function saveGame() {
-  saveGameState(getCombinedModeId(), {
-    grid,
-    moveCount,
-    score: getScore(),
-    displayScore: getDisplayScore(),
-    chainLevel: getChainLevel(),
-    comboCount: getComboCount(),
-    maxCombo: getMaxCombo(),
-  });
-}
-
-// ─── Cascade logic ──────────────────────────────────────────────
-
-async function startCascade() {
-  state = 'cascading';
-
-  const matches = findMatchesForMode(grid, activeCols, activeRows);
-  if (matches.size === 0) {
-    // No match — just deselect
-    selectedCluster = null;
-    state = 'idle';
-    resetChain();
-    return;
-  }
-
-  await runCascade(getAnimationContext(), matches);
-
-  selectedCluster = null;
-  state = 'idle';
-  resetChain();
-}
-
 // ─── Helpers ────────────────────────────────────────────────────
 
 /** Read the name from an input and persist it as the sticky player name. */
@@ -1279,12 +717,6 @@ function commitScoreFromInput(inputId, achievement) {
   addHighScore(modeId, getScore(), achievement, getMaxCombo());
   // Records: single best-ever score per mode, alongside the leaderboard (R4).
   recordModeScore(modeId, getScore());
-}
-
-function clustersMatch(a, b) {
-  if (!a || !b || a.length !== b.length) return false;
-  const setA = new Set(a.map(h => `${h.col},${h.row}`));
-  return b.every(h => setA.has(`${h.col},${h.row}`));
 }
 
 // ─── Game Over overlay ──────────────────────────────────────────

--- a/js/main.js
+++ b/js/main.js
@@ -9,28 +9,17 @@
  */
 
 import {
-  GRID_COLS, GRID_ROWS,
-  MATCH_FLASH_MS, GRAVITY_MS,
-  ROTATION_POP_MS, ROTATION_SETTLE_MS,
-  BOMB_SPAWN_INTERVAL, BOMB_INITIAL_TIMER,
+  GRID_COLS, GRID_ROWS, BOMB_INITIAL_TIMER,
 } from './constants.js';
+import { createGrid, findMatchesForMode } from './board.js';
 import {
-  createGrid, rotateCluster, rotateRing,
-  findMatches, findMatchesForMode,
-  applyGravity, fillEmpty,
-} from './board.js';
-import {
-  initRenderer, resize, drawFrame, getOrigin, getBoardScale,
+  initRenderer, resize, drawFrame, getOrigin,
   setCellOverride, clearCellOverride, clearAllOverrides,
-  addFloatingPiece, removeFloatingPiece,
-  spawnCreationParticles, spawnScorePopup,
-  spawnColorNukeParticles, spawnExplosionParticles,
-  spawnRingShockwave, flashScreenOverlay,
   requestRedraw, clearDirty, getIsDirty, hasActiveRendererAnimations,
   setActiveGridSize, setFontScale,
 } from './renderer.js';
 import {
-  loadActiveMode, getActiveGameMode, getActiveMatchMode,
+  loadActiveMode, getActiveGameMode,
   getActiveGameModeId, getCombinedModeId,
   setActiveGameMode, getAllGameModes
 } from './modes.js';
@@ -41,27 +30,27 @@ import {
 } from './input.js';
 import { registerFrameLoop, wakeFrameLoop } from './frame.js';
 import { openModal, closeModal, registerModalHost } from './modal.js';
+import { shakeRefusal, prepopulateNameInputs } from './ui.js';
 
 import {
   animateClusterRotation, animateRingRotation, animateYRotation,
   animateBlackPearlCreation, animateGrandPoobahCreation, animateStarflowerCreation,
-  handleOverAchiever, handleGameOver, runCascade, computeFallDistances, delay
+  handleOverAchiever, handleGameOver, runCascade, delay
 } from './animations.js';
-import { tween, updateTweens, suspendTweenClock, easeOutCubic, easeOutBounce, hasActiveTweens, linear } from './tween.js';
+import { tween, updateTweens, suspendTweenClock, hasActiveTweens, linear } from './tween.js';
 import {
-  resetScore, awardMatch, advanceChain, resetChain,
+  resetScore, advanceChain, resetChain,
   updateDisplayScore, restoreScore,
   getScore, getDisplayScore, getChainLevel, getComboCount, getMaxCombo, isScoreAnimating
 } from './score.js';
 import {
-  detectStarflowers, detectStarflowersAtCleared,
-  detectBlackPearls, detectMultiplierClusters, detectGrandPoobahs,
-  detectGrandPoobahRing, tickBombs, countBombs,
+  detectStarflowers, detectBlackPearls, detectGrandPoobahs,
+  detectGrandPoobahRing, tickBombs,
 } from './specials.js';
 import {
   saveGameState, loadGameState, clearGameState,
   addHighScore, getHighScores,
-  getPlayerName, setPlayerName,
+  setPlayerName,
   loadSettings, saveSettings,
   recordModeScore, seedRecordsFromScores,
 } from './storage.js';
@@ -73,8 +62,7 @@ import {
 } from './audio.js';
 import {
   initPuzzleModeUI, showPuzzleSelector, registerPuzzleCallbacks,
-  clearActivePuzzle, getActivePuzzle, getPuzzleMovesLeft,
-  onPuzzleMove, onStarflowerCreated,
+  clearActivePuzzle, getActivePuzzle, onPuzzleMove,
 } from './puzzle-mode.js';
 
 
@@ -115,7 +103,7 @@ let boardGeneration = 0;  // incremented on grid replacement; stale async chains
 // ─── Bootstrap ──────────────────────────────────────────────────
 
 /** True while the board is mid-animation (rotating, cascading). UI should not restart. */
-export function isProcessing() {
+function isProcessing() {
   return state === 'rotating' || state === 'cascading';
 }
 
@@ -148,12 +136,21 @@ registerModalHost({
   resume: resumeFromPause,
 });
 
-// DEBUG: Expose internals
-window.debug = {
-  getGrid: () => grid,
-  getState: () => state,
-  runPostRotation: () => postRotationCheck(boardGeneration),
-};
+// Developer hook, opt-in only: load the game with `?debug` or `#debug`.
+//
+// It was unconditional, which put a live handle on the state machine —
+// including runPostRotation(), which drives the cascade — on every player's
+// page, and left `window.debug` claimed against anything else that wants the
+// name. Nothing in the game or the suite reads it, so a gate costs nothing;
+// the URL is the gate because it is the one knob available from inside the
+// launcher's iframe.
+if (/(^|[?&#])debug\b/.test(window.location.search + window.location.hash)) {
+  window.debug = {
+    getGrid: () => grid,
+    getState: () => state,
+    runPostRotation: () => postRotationCheck(boardGeneration),
+  };
+}
 
 const canvas = document.getElementById('game');
 initRenderer(canvas);
@@ -294,12 +291,11 @@ document.getElementById('btn-close-scores').addEventListener('click', (e) => {
 
 // Shared guard: shake a button and bail if board is mid-animation.
 // Prevents restart clicks during cascade/rotation feeling like they're ignored.
+// The shake itself lives in js/ui.js — puzzle-mode.js refuses the same
+// way and the gesture is fiddly enough to be worth having exactly one of.
 function guardedAction(btn, action) {
   if (isProcessing()) {
-    btn.classList.remove('shake-animation');
-    void btn.offsetWidth; // force reflow to restart animation
-    btn.classList.add('shake-animation');
-    setTimeout(() => btn.classList.remove('shake-animation'), 400);
+    shakeRefusal(btn);
     return;
   }
   action();
@@ -328,13 +324,6 @@ function toggleModeDropdown() {
   }
   requestRedraw();
 }
-
-// Close dropdown if clicking elsewhere
-window.addEventListener('click', (e) => {
-  if (!logoDropdown.contains(e.target) && state === 'idle') {
-    // Rely on canvas click handler instead since standard clicks intercept on canvas
-  }
-});
 
 // Game HUD logo opens the mode dropdown
 document.getElementById('game-hud-logo')?.addEventListener('click', (e) => {
@@ -530,29 +519,63 @@ function updateControlsVisibility() {
 
 const MODE_LABELS = { arcade: '💣 Arcade', chill: '✨ Chill', puzzle: '🧩 Puzzle' };
 
+// updateGameHUD() runs on every rendered frame, so it used to do three
+// getElementById lookups and three unconditional textContent/dataset writes per
+// frame, for values that change a few times a second at most — and a write is a
+// style invalidation whether or not the string actually differs.
+//
+// The three nodes are static in index.html and nothing ever replaces them, so
+// they are resolved once and kept. Resolution is lazy only so that this block
+// does not have to sit below the DOM-ready point; the first caller is
+// syncHUDForMode() at bootstrap.
+const hudEls = { resolved: false, hud: null, mode: null, score: null };
+function hudElements() {
+  if (!hudEls.resolved) {
+    hudEls.resolved = true;
+    hudEls.hud   = document.getElementById('game-hud');
+    hudEls.mode  = document.getElementById('game-hud-mode');
+    hudEls.score = document.getElementById('hud-score-value');
+  }
+  return hudEls;
+}
+
+// The score readout is the one node main.js writes exclusively, so the last
+// value can be remembered — which also skips the toLocaleString() on an
+// unchanged frame. The mode name and the layout attribute are NOT exclusive:
+// puzzle-mode.js's showPuzzleHUD() writes both directly. Those are therefore
+// compared against what the DOM actually holds rather than against a
+// remembered value, because a remembered value would go stale the moment a
+// puzzle started and the next real change would be skipped.
+let hudLastScore = null;
+
 /** Sync the HTML game-hud to the current mode and score. */
 function updateGameHUD() {
   const mode = getActiveGameMode();
-  const hud = document.getElementById('game-hud');
-  if (!hud) return;
+  const els = hudElements();
+  if (!els.hud) return;
 
   // Skip score updates when puzzle mode owns the right-side group
   if (mode.isPuzzle) return;
 
-  hud.dataset.mode = mode.id;
-  const modeEl    = document.getElementById('game-hud-mode');
-  const scoreEl   = document.getElementById('hud-score-value');
+  if (els.hud.dataset.mode !== mode.id) els.hud.dataset.mode = mode.id;
 
-  if (modeEl)  modeEl.textContent  = MODE_LABELS[mode.id] || mode.label;
-  if (scoreEl) scoreEl.textContent = getDisplayScore().toLocaleString();
+  const label = MODE_LABELS[mode.id] || mode.label;
+  if (els.mode && els.mode.textContent !== label) els.mode.textContent = label;
+
+  const score = getDisplayScore();
+  if (els.score && score !== hudLastScore) {
+    els.score.textContent = score.toLocaleString();
+    hudLastScore = score;
+  }
 }
 
 /** Called when switching modes to reconfigure the HUD layout. */
 function syncHUDForMode(modeId) {
-  const hud = document.getElementById('game-hud');
+  const els = hudElements();
+  const hud = els.hud;
   if (hud) hud.dataset.mode = modeId;
 
-  const modeEl      = document.getElementById('game-hud-mode');
+  const modeEl      = els.mode;
   const subtitleEl   = document.getElementById('game-hud-subtitle');
   const scoreGroup  = document.getElementById('hud-score-group');
   const puzzleGroup = document.getElementById('hud-puzzle-group');
@@ -608,7 +631,6 @@ if (hasUrlConfig) {
   window.history.replaceState({ path: cleanUrl }, '', cleanUrl);
 }
 const activeGameMode = getActiveGameMode();
-const activeMatchMode = getActiveMatchMode();
 
 if (activeGameMode.id === 'chill') {
   document.getElementById('dropdown-btn-end-session').classList.remove('hidden');
@@ -623,7 +645,6 @@ if (savedState) {
   restoreScore(savedState);
   moveCount = savedState.moveCount || 0;
   state = 'idle';
-  console.log('Game state loaded.');
 } else {
   resetScore();
   grid = createGrid();
@@ -1242,15 +1263,6 @@ async function startCascade() {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────
-
-/** Prepopulate all name inputs with the sticky player name. */
-function prepopulateNameInputs() {
-  const name = getPlayerName();
-  for (const id of ['go-name', 'gw-name', 'oa-name', 'es-name']) {
-    const el = document.getElementById(id);
-    if (el) el.value = name;
-  }
-}
 
 /** Read the name from an input and persist it as the sticky player name. */
 function setNameFromInput(inputId) {

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,189 @@
+/**
+ * modal.js — the one place a modal opens and closes.
+ *
+ * Before this module, opening and closing a modal was hand-rolled at every
+ * call site, and there were two incompatible conventions. main.js's modals set
+ * `isPaused = true` on open and closed through `resumeFromPause()`; the puzzle
+ * selector, result, failed and editor modals never touched the pause flag at
+ * all, so the board went on animating and eating clicks behind them. The #57
+ * commit records six handlers that cleared `isPaused` without waking the loop
+ * — that class of bug recurs precisely because the sequence lives at the call
+ * site instead of in one function.
+ *
+ * So: one seam, four responsibilities, no exceptions.
+ *
+ *   1. the `hidden` class on the modal root,
+ *   2. the pause flag (per the policy table below),
+ *   3. `resume()` on close — clearing the flag is not enough on its own, a
+ *      parked loop does not restart because a boolean flipped (#55/#57),
+ *   4. `clearPendingAction()` on close, so the click that dismissed the modal
+ *      does not survive as a queued gesture the board answers on the next
+ *      frame (ghost click; js/input.js).
+ *
+ * Two things this module deliberately does NOT do:
+ *
+ *   - It never starts the frame loop itself. The host's resume() calls
+ *     `wakeFrameLoop()`, which asks the gate registered in main.js
+ *     (`() => !isPaused`). That gate stays the sole authority on whether a
+ *     redraw may put frames back on the schedule; a second path from here
+ *     would be exactly the bug the gate exists to prevent.
+ *   - It never touches the tween clock. `parkFrameLoop()` in main.js calls
+ *     `suspendTweenClock()` on the frame that observes the pause, which is the
+ *     only moment that knows a gap is about to open (#63). Suspending from
+ *     here as well would be a second, earlier, redundant call.
+ *
+ * DOM-only and host-injected on purpose: it imports nothing from main.js, so
+ * it stays importable in node and survives the state-machine extraction.
+ */
+
+import { clearPendingAction } from './input.js';
+
+/**
+ * Every modal root in index.html, and whether opening it parks the game loop.
+ *
+ * PAUSING (the default, and the right answer for anything the player opens on
+ * a live board): the board must not animate or consume input behind a modal.
+ * This includes the puzzle selector and the puzzle editor — both of them
+ * replace the board outright the moment the player picks something, so there
+ * is nothing behind them worth keeping warm, and leaving the loop running
+ * meant a puzzle could tick its bomb fuses while the player browsed the menu.
+ *
+ * NON-PAUSING (the five end-of-run modals): these are opened *over a
+ * running animation on purpose*. handleGameOver() and handleOverAchiever()
+ * show the modal and then `await tween(1500, …)` to blow the board apart
+ * behind it; handleGameWin() is the tail of animateGrandPoobahCreation(),
+ * which its caller is still awaiting inside the cascade loop. Pausing any of
+ * the three would park the loop that advances those tweens, the awaits would
+ * never settle, and the game would hang — a strictly worse bug than the one
+ * this module fixes. They do not need the pause anyway: they are only ever
+ * shown with `state === 'gameover'`, which already refuses input, drains the
+ * gesture queue and parks the loop as soon as the explosion has finished.
+ * Their close handlers still go through closeModal() and so still resume and
+ * clear the pending action like everything else.
+ *
+ * modal-puzzle-result and modal-puzzle-failed are non-pausing for the same
+ * reason. Both call _onPuzzleEnd() the moment they open, which sets
+ * `state = 'gameover'`, so input is already refused without the pause — and
+ * both are opened from a setTimeout(600) scheduled by onPuzzleMove(). That
+ * deferral is what makes pausing them actively harmful: a puzzle solved on the
+ * same move a pre-placed bomb expires runs handleGameOver()'s 1500 ms
+ * explosion, and the modal landing 600 ms into it would park the loop and
+ * leave the board frozen mid-detonation until the player dismissed it.
+ */
+export const MODAL_POLICY = {
+  'modal-help':          { pause: true },
+  'modal-scores':        { pause: true },
+  'modal-settings':      { pause: true },
+  'modal-end-session':   { pause: true },
+  'modal-puzzle-select': { pause: true },
+  'modal-puzzle-editor': { pause: true },
+  'modal-puzzle-result': { pause: false },
+  'modal-puzzle-failed': { pause: false },
+  'modal-gameover':      { pause: false },
+  'modal-gamewin':       { pause: false },
+  'modal-over-achiever': { pause: false },
+};
+
+/** @type {string[]} every id the seam knows about — the gate test reads this. */
+export const MODAL_IDS = Object.keys(MODAL_POLICY);
+
+// ─── Host ───────────────────────────────────────────────────────
+//
+// Same shape as frame.js: inert until the owner of the pause flag registers,
+// so importing this module in node costs nothing and asserts nothing.
+
+const NOOP_HOST = { pause() {}, resume() {} };
+let host = NOOP_HOST;
+
+/**
+ * @param {{pause: () => void, resume: () => void}} h — `pause` sets the pause
+ *        flag; `resume` is main.js's resumeFromPause() (clear flag, reset
+ *        lastTime, wake the loop through the gate).
+ */
+export function registerModalHost(h) {
+  host = {
+    pause:  typeof h?.pause  === 'function' ? h.pause  : NOOP_HOST.pause,
+    resume: typeof h?.resume === 'function' ? h.resume : NOOP_HOST.resume,
+  };
+}
+
+/** Test seam: drop the host and forget which modals are open. */
+export function resetModalSeam() {
+  host = NOOP_HOST;
+  openIds.clear();
+}
+
+// ─── Open / close ───────────────────────────────────────────────
+
+/** @type {Set<string>} ids currently open, in the seam's own reckoning. */
+const openIds = new Set();
+
+function policyFor(id) {
+  const policy = MODAL_POLICY[id];
+  if (!policy) {
+    // A modal the seam does not know about would silently skip the pause, which
+    // is the exact failure this module exists to make impossible. Fail loudly
+    // and treat it as pausing, the safe default.
+    console.error(`modal.js: unknown modal id "${id}" — add it to MODAL_POLICY`);
+    return { pause: true };
+  }
+  return policy;
+}
+
+function root(id) {
+  return typeof document === 'undefined' ? null : document.getElementById(id);
+}
+
+/** True while any *pausing* modal is open — the condition that holds the pause. */
+function pauseHeld() {
+  for (const id of openIds) {
+    if (MODAL_POLICY[id]?.pause !== false) return true;
+  }
+  return false;
+}
+
+/**
+ * Show a modal. Pauses the game unless the policy table says otherwise.
+ * @param {string} id — a key of MODAL_POLICY.
+ */
+export function openModal(id) {
+  const { pause } = policyFor(id);
+  root(id)?.classList.remove('hidden');
+  openIds.add(id);
+  if (pause) host.pause();
+}
+
+/**
+ * Hide a modal and come back from it.
+ *
+ * Safe to call on a modal that is already closed: several paths close
+ * defensively (startPuzzle() hides all three puzzle modals on its way in,
+ * over whichever one the player actually clicked), and a resume must never
+ * depend on which of two close calls happened to run first.
+ *
+ * The pause is lifted only once no pausing modal is left open, so closing a
+ * modal that was never showing cannot unpause the game behind one that is.
+ *
+ * @param {string} id — a key of MODAL_POLICY.
+ */
+export function closeModal(id) {
+  policyFor(id);
+  root(id)?.classList.add('hidden');
+  openIds.delete(id);
+
+  // Ghost-click protection: unconditional, because the dismissing click is
+  // queued whether or not this particular modal was the one showing.
+  clearPendingAction();
+
+  if (!pauseHeld()) host.resume();
+}
+
+/** @param {string} id @returns {boolean} */
+export function isModalOpen(id) {
+  return openIds.has(id);
+}
+
+/** @returns {string[]} open modal ids, for tests and debugging. */
+export function getOpenModals() {
+  return [...openIds];
+}

--- a/js/modal.js
+++ b/js/modal.js
@@ -182,8 +182,3 @@ export function closeModal(id) {
 export function isModalOpen(id) {
   return openIds.has(id);
 }
-
-/** @returns {string[]} open modal ids, for tests and debugging. */
-export function getOpenModals() {
-  return [...openIds];
-}

--- a/js/modal.js
+++ b/js/modal.js
@@ -49,13 +49,17 @@ import { clearPendingAction } from './input.js';
  * meant a puzzle could tick its bomb fuses while the player browsed the menu.
  *
  * NON-PAUSING (the five end-of-run modals): these are opened *over a
- * running animation on purpose*. handleGameOver() and handleOverAchiever()
- * show the modal and then `await tween(1500, …)` to blow the board apart
- * behind it; handleGameWin() is the tail of animateGrandPoobahCreation(),
- * which its caller is still awaiting inside the cascade loop. Pausing any of
- * the three would park the loop that advances those tweens, the awaits would
- * never settle, and the game would hang — a strictly worse bug than the one
- * this module fixes. They do not need the pause anyway: they are only ever
+ * running animation on purpose*. game-state.js's handleGameOver() and
+ * handleOverAchiever() show the modal — through the host hook main.js
+ * registers — and then `await explodeBoard()`, which is a 1500 ms tween that
+ * blows the board apart behind it; handleGameWin() is called from inside
+ * postRotationCheck()'s cascade loop, which goes on awaiting further steps
+ * after it. (hecknsic#66 moved all three out of animations.js; what they do,
+ * and the order they do it in, is unchanged — the modal still goes up first
+ * and the tween is still awaited behind it.) Pausing any of the three would
+ * park the loop that advances those tweens, the awaits would never settle,
+ * and the game would hang — a strictly worse bug than the one this module
+ * fixes. They do not need the pause anyway: they are only ever
  * shown with `state === 'gameover'`, which already refuses input, drains the
  * gesture queue and parks the loop as soon as the explosion has finished.
  * Their close handlers still go through closeModal() and so still resume and

--- a/js/modes.js
+++ b/js/modes.js
@@ -28,19 +28,20 @@ export function loadActiveMode() {
 export function getActiveGameMode()   { return GAME_MODES[activeGameModeId] || GAME_MODES.arcade; }
 export function getActiveMatchMode()  { return MATCH_MODES[activeMatchModeId] || MATCH_MODES.classic; }
 export function getActiveGameModeId() { return activeGameModeId; }
-export function getActiveMatchModeId() { return activeMatchModeId; }
-// Used for high score storage keys:
+
+/**
+ * Storage-key component, and FROZEN SCHEMA. Match mode collapsed to a single
+ * 'classic' entry long ago, but the `_classic` suffix is baked into every
+ * persisted key already on players' devices
+ * (arcade.v1.hecknsic.gameState.arcade_classic, and the high-score keys).
+ * The unused setter/list/id accessors around it were deleted; this string
+ * must not change without a migration.
+ */
 export function getCombinedModeId() { return `${activeGameModeId}_${activeMatchModeId}`; }
 
 export function getAllGameModes()      { return Object.values(GAME_MODES); }
-export function getAllMatchModes()     { return Object.values(MATCH_MODES); }
 
 export function setActiveGameMode(id) {
   activeGameModeId = id;
   Arcade.state.set('activeGameMode', id);
-}
-
-export function setActiveMatchMode(id) {
-  activeMatchModeId = id;
-  Arcade.state.set('activeMatchMode', id);
 }

--- a/js/power.js
+++ b/js/power.js
@@ -29,8 +29,9 @@ export function isPowerSaving() { return saving; }
 /** Subscribe to transitions. Called with the new value, only when it changes. */
 export function onPowerSaverChange(fn) { listeners.push(fn); }
 
-/** Re-read and fan out. Exported for tests; wired to onSettingsChange below. */
-export function refreshPowerSaver() {
+/** Re-read and fan out. Wired to onSettingsChange below — that subscription
+ *  is how the suite drives it, so it needs no export of its own. */
+function refreshPowerSaver() {
   const next = readSetting();
   if (next === saving) return saving;
   saving = next;

--- a/js/puzzle-editor.js
+++ b/js/puzzle-editor.js
@@ -11,8 +11,8 @@
  * No server required.
  */
 
-import { encodePuzzleBoard, decodePuzzleBoard, describeGoal } from './puzzles.js';
-import { GRID_COLS, GRID_ROWS, PIECE_COLORS } from './constants.js';
+import { encodePuzzleBoard } from './puzzles.js';
+import { GRID_COLS, GRID_ROWS } from './constants.js';
 import { openModal, closeModal } from './modal.js';
 
 // ─── Share code encode/decode ───────────────────────────────────

--- a/js/puzzle-editor.js
+++ b/js/puzzle-editor.js
@@ -13,6 +13,7 @@
 
 import { encodePuzzleBoard, decodePuzzleBoard, describeGoal } from './puzzles.js';
 import { GRID_COLS, GRID_ROWS, PIECE_COLORS } from './constants.js';
+import { openModal, closeModal } from './modal.js';
 
 // ─── Share code encode/decode ───────────────────────────────────
 
@@ -91,7 +92,7 @@ export function initPuzzleEditorUI() {
       showEditorStatus('❌ Invalid code', 'error');
       return;
     }
-    document.getElementById('modal-puzzle-editor').classList.add('hidden');
+    closeModal('modal-puzzle-editor');
     if (_startPuzzleFn) _startPuzzleFn(puzzle);
   });
 
@@ -151,7 +152,9 @@ export function initPuzzleEditorUI() {
     const goal      = buildGoalFromEditor(goalType, goalParam);
 
     const puzzle = { id: 'custom', name, description: '', cols, rows, moveLimit, par, noRefill: true, goal, board };
-    document.getElementById('modal-puzzle-editor').classList.add('hidden');
+    // Close before starting: startPuzzle() can refuse (mid-animation), and the
+    // editor must not be left holding the pause when it does.
+    closeModal('modal-puzzle-editor');
     if (_startPuzzleFn) _startPuzzleFn(puzzle);
   });
 
@@ -162,7 +165,7 @@ export function initPuzzleEditorUI() {
 
   // Close editor
   document.getElementById('btn-close-puzzle-editor')?.addEventListener('click', () => {
-    document.getElementById('modal-puzzle-editor').classList.add('hidden');
+    closeModal('modal-puzzle-editor');
   });
 }
 
@@ -227,5 +230,8 @@ export function showPuzzleEditor() {
   if (colsEl) colsEl.value = GRID_COLS;
   if (rowsEl) rowsEl.value = GRID_ROWS;
   updateGoalParamLabel(document.getElementById('editor-goal-type')?.value ?? 'clear_color');
-  document.getElementById('modal-puzzle-editor').classList.remove('hidden');
+  // Pauses, like the selector: the editor's capture button reads the live
+  // board, and every way out of it either replaces that board or returns to a
+  // board the player was not playing meanwhile.
+  openModal('modal-puzzle-editor');
 }

--- a/js/puzzle-mode.js
+++ b/js/puzzle-mode.js
@@ -30,6 +30,7 @@ import {
 } from './storage.js';
 import { getTodaysPuzzle, getDailyDateString, getDailyProgress } from './daily-puzzle.js';
 import { showPuzzleEditor, registerEditorCallbacks, initPuzzleEditorUI } from './puzzle-editor.js';
+import { openModal, closeModal } from './modal.js';
 
 // ─── Active puzzle state ────────────────────────────────────────
 
@@ -243,7 +244,7 @@ export function showPuzzleSelector() {
 
         btn.addEventListener('click', (e) => {
           if (refuseWhileProcessing(e.currentTarget)) return;
-          document.getElementById('modal-puzzle-select').classList.add('hidden');
+          closeModal('modal-puzzle-select');
           startPuzzle(puzzle.id);
         });
 
@@ -254,7 +255,7 @@ export function showPuzzleSelector() {
     container.appendChild(sectorEl);
   }
 
-  document.getElementById('modal-puzzle-select').classList.remove('hidden');
+  openModal('modal-puzzle-select');
 }
 
 // ─── Puzzle HUD ─────────────────────────────────────────────────
@@ -346,7 +347,7 @@ function showPuzzleResult(stars) {
     nextBtn.dataset.nextId = nextPuzzle?.id ?? '';
   }
 
-  document.getElementById('modal-puzzle-result').classList.remove('hidden');
+  openModal('modal-puzzle-result');
 
   if (_onPuzzleEnd) _onPuzzleEnd('complete');
 }
@@ -382,7 +383,7 @@ function showPuzzleFailed(reason) {
   const recordEl = document.getElementById('puzzle-failed-new-record');
   if (recordEl) recordEl.style.display = isNewRecord ? 'block' : 'none';
 
-  document.getElementById('modal-puzzle-failed').classList.remove('hidden');
+  openModal('modal-puzzle-failed');
 
   if (_onPuzzleEnd) _onPuzzleEnd('failed');
 }
@@ -489,10 +490,19 @@ function hasValidMoves(grid, cols, rows) {
   return false;
 }
 
+/**
+ * Close all three puzzle modals through the seam, whichever one is showing.
+ *
+ * startPuzzle() calls this on its way in, so every path that ends in a new
+ * board — retry, next, the selector, the daily button, the editor's play
+ * button — resumes the loop even if the handler forgot to close its own modal
+ * first. closeModal() is a no-op on a modal that is already hidden, and only
+ * lifts the pause once none of them is left open.
+ */
 function hidePuzzleModals() {
-  ['modal-puzzle-select', 'modal-puzzle-result', 'modal-puzzle-failed'].forEach(id => {
-    document.getElementById(id)?.classList.add('hidden');
-  });
+  closeModal('modal-puzzle-select');
+  closeModal('modal-puzzle-result');
+  closeModal('modal-puzzle-failed');
 }
 
 // ─── Modal button wiring ────────────────────────────────────────
@@ -507,13 +517,15 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   // Daily puzzle play button
   document.getElementById('btn-play-daily')?.addEventListener('click', (e) => {
     if (refuseWhileProcessing(e.currentTarget)) return;
-    document.getElementById('modal-puzzle-select').classList.add('hidden');
+    closeModal('modal-puzzle-select');
     startPuzzle(getTodaysPuzzle());
   });
 
   // Open puzzle editor from selector
   document.getElementById('btn-open-puzzle-editor')?.addEventListener('click', () => {
-    document.getElementById('modal-puzzle-select').classList.add('hidden');
+    // Selector out, editor in. Both pause, so the seam never lifts the pause
+    // between the two — closeModal() sees the editor is about to hold it.
+    closeModal('modal-puzzle-select');
     showPuzzleEditor();
   });
 
@@ -525,13 +537,13 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
 
   // Close puzzle selector
   document.getElementById('btn-close-puzzle-select')?.addEventListener('click', () => {
-    document.getElementById('modal-puzzle-select').classList.add('hidden');
+    closeModal('modal-puzzle-select');
   });
 
   // Result modal: retry
   document.getElementById('btn-puzzle-retry')?.addEventListener('click', (e) => {
     if (refuseWhileProcessing(e.currentTarget)) return;
-    document.getElementById('modal-puzzle-result').classList.add('hidden');
+    closeModal('modal-puzzle-result');
     if (activePuzzle) startPuzzle(activePuzzle.id);
   });
 
@@ -540,7 +552,7 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
     if (refuseWhileProcessing(e.currentTarget)) return;
     const nextId = e.currentTarget.dataset.nextId;
     if (nextId) {
-      document.getElementById('modal-puzzle-result').classList.add('hidden');
+      closeModal('modal-puzzle-result');
       startPuzzle(nextId);
     }
   });
@@ -549,7 +561,7 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   // replaces no board, so there is nothing to corrupt, and refusing the only
   // way out of a modal is a soft-lock waiting to happen.
   document.getElementById('btn-puzzle-menu')?.addEventListener('click', () => {
-    document.getElementById('modal-puzzle-result').classList.add('hidden');
+    closeModal('modal-puzzle-result');
     clearActivePuzzle();
     showPuzzleSelector();
   });
@@ -557,13 +569,13 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   // Failed modal: retry
   document.getElementById('btn-puzzle-failed-retry')?.addEventListener('click', (e) => {
     if (refuseWhileProcessing(e.currentTarget)) return;
-    document.getElementById('modal-puzzle-failed').classList.add('hidden');
+    closeModal('modal-puzzle-failed');
     if (activePuzzle) startPuzzle(activePuzzle.id);
   });
 
   // Failed modal: menu — unguarded for the same reason as btn-puzzle-menu.
   document.getElementById('btn-puzzle-failed-menu')?.addEventListener('click', () => {
-    document.getElementById('modal-puzzle-failed').classList.add('hidden');
+    closeModal('modal-puzzle-failed');
     clearActivePuzzle();
     showPuzzleSelector();
   });
@@ -571,7 +583,7 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   // Failed modal: dismiss (X button or click outside)
   const failedModal = document.getElementById('modal-puzzle-failed');
   const dismissFailed = () => {
-    failedModal.classList.add('hidden');
+    closeModal('modal-puzzle-failed');
     showPuzzleHUD(true);
   };
   document.getElementById('btn-puzzle-failed-dismiss')?.addEventListener('click', dismissFailed);

--- a/js/puzzle-mode.js
+++ b/js/puzzle-mode.js
@@ -10,7 +10,6 @@
 
 import {
   PUZZLE_SECTORS,
-  ALL_PUZZLES,
   getPuzzleById,
   getNextPuzzle,
   decodePuzzleBoard,
@@ -31,6 +30,7 @@ import {
 import { getTodaysPuzzle, getDailyDateString, getDailyProgress } from './daily-puzzle.js';
 import { showPuzzleEditor, registerEditorCallbacks, initPuzzleEditorUI } from './puzzle-editor.js';
 import { openModal, closeModal } from './modal.js';
+import { shakeRefusal } from './ui.js';
 
 // ─── Active puzzle state ────────────────────────────────────────
 
@@ -50,17 +50,14 @@ let _isProcessing  = () => false;
 
 /**
  * Refuse a board-replacing click while the board is animating, shaking the
- * button so the refusal reads as deliberate. Mirrors guardedAction in main.js.
+ * button so the refusal reads as deliberate. The mirror of guardedAction in
+ * main.js — the two differ only in busy-predicate and return shape, and share
+ * the shake itself through js/ui.js.
  * @returns {boolean} true when the caller must bail.
  */
 function refuseWhileProcessing(btn) {
   if (!_isProcessing()) return false;
-  if (btn) {
-    btn.classList.remove('shake-animation');
-    void btn.offsetWidth; // force reflow to restart animation
-    btn.classList.add('shake-animation');
-    setTimeout(() => btn.classList.remove('shake-animation'), 400);
-  }
+  shakeRefusal(btn);
   return true;
 }
 
@@ -72,9 +69,6 @@ export function registerPuzzleCallbacks(onLoad, onEnd) {
 }
 
 export function getActivePuzzle()   { return activePuzzle; }
-export function getPuzzleMovesLeft(){ return activePuzzle ? activePuzzle.moveLimit - movesUsed : 0; }
-export function getPuzzleMovesUsed(){ return movesUsed; }
-export function getPuzzleStats()    { return stats; }
 
 /**
  * Load and start a puzzle by id or by puzzle object directly (custom/daily).

--- a/js/puzzle-mode.js
+++ b/js/puzzle-mode.js
@@ -43,6 +43,25 @@ let _onPuzzleLoad  = null;  // callback(grid, cols, rows, puzzle) — set by mai
 let _onPuzzleEnd   = null;  // callback(reason) — 'complete' | 'failed'
 // Custom/daily puzzle cache — capped at 14 entries (LRU by insertion order via Map)
 let _customPuzzles = new Map();
+// True while the board is mid-animation. Loading a puzzle then would hand the
+// in-flight animation a board that no longer exists. Injected by main.js.
+let _isProcessing  = () => false;
+
+/**
+ * Refuse a board-replacing click while the board is animating, shaking the
+ * button so the refusal reads as deliberate. Mirrors guardedAction in main.js.
+ * @returns {boolean} true when the caller must bail.
+ */
+function refuseWhileProcessing(btn) {
+  if (!_isProcessing()) return false;
+  if (btn) {
+    btn.classList.remove('shake-animation');
+    void btn.offsetWidth; // force reflow to restart animation
+    btn.classList.add('shake-animation');
+    setTimeout(() => btn.classList.remove('shake-animation'), 400);
+  }
+  return true;
+}
 
 // ─── Public API ─────────────────────────────────────────────────
 
@@ -60,6 +79,9 @@ export function getPuzzleStats()    { return stats; }
  * Load and start a puzzle by id or by puzzle object directly (custom/daily).
  */
 export function startPuzzle(puzzleIdOrObject) {
+  // Backstop for any start path that did not check first (the editor's play
+  // button among them): replacing the board mid-animation corrupts it.
+  if (_isProcessing()) return;
   let puzzle;
   if (typeof puzzleIdOrObject === 'object') {
     puzzle = puzzleIdOrObject;
@@ -219,7 +241,8 @@ export function showPuzzleSelector() {
         btn.appendChild(info);
         btn.appendChild(starDisplay);
 
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (e) => {
+          if (refuseWhileProcessing(e.currentTarget)) return;
           document.getElementById('modal-puzzle-select').classList.add('hidden');
           startPuzzle(puzzle.id);
         });
@@ -475,12 +498,15 @@ function hidePuzzleModals() {
 // ─── Modal button wiring ────────────────────────────────────────
 
 export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
+  _isProcessing = isProcessingFn;
+
   // Init puzzle editor (pass grid capture + start callbacks)
   initPuzzleEditorUI();
   registerEditorCallbacks(getGridFn, startPuzzle);
 
   // Daily puzzle play button
-  document.getElementById('btn-play-daily')?.addEventListener('click', () => {
+  document.getElementById('btn-play-daily')?.addEventListener('click', (e) => {
+    if (refuseWhileProcessing(e.currentTarget)) return;
     document.getElementById('modal-puzzle-select').classList.add('hidden');
     startPuzzle(getTodaysPuzzle());
   });
@@ -492,8 +518,9 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   });
 
   // Restart puzzle (always-visible HUD button)
-  document.getElementById('btn-puzzle-restart')?.addEventListener('click', () => {
-    if (activePuzzle && !isProcessingFn()) startPuzzle(activePuzzle.id);
+  document.getElementById('btn-puzzle-restart')?.addEventListener('click', (e) => {
+    if (refuseWhileProcessing(e.currentTarget)) return;
+    if (activePuzzle) startPuzzle(activePuzzle.id);
   });
 
   // Close puzzle selector
@@ -502,13 +529,15 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   });
 
   // Result modal: retry
-  document.getElementById('btn-puzzle-retry')?.addEventListener('click', () => {
+  document.getElementById('btn-puzzle-retry')?.addEventListener('click', (e) => {
+    if (refuseWhileProcessing(e.currentTarget)) return;
     document.getElementById('modal-puzzle-result').classList.add('hidden');
     if (activePuzzle) startPuzzle(activePuzzle.id);
   });
 
   // Result modal: next
   document.getElementById('btn-puzzle-next')?.addEventListener('click', (e) => {
+    if (refuseWhileProcessing(e.currentTarget)) return;
     const nextId = e.currentTarget.dataset.nextId;
     if (nextId) {
       document.getElementById('modal-puzzle-result').classList.add('hidden');
@@ -516,7 +545,9 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
     }
   });
 
-  // Result modal: back to menu
+  // Result modal: back to menu. Deliberately NOT guarded: clearActivePuzzle()
+  // replaces no board, so there is nothing to corrupt, and refusing the only
+  // way out of a modal is a soft-lock waiting to happen.
   document.getElementById('btn-puzzle-menu')?.addEventListener('click', () => {
     document.getElementById('modal-puzzle-result').classList.add('hidden');
     clearActivePuzzle();
@@ -524,12 +555,13 @@ export function initPuzzleModeUI(getGridFn, isProcessingFn = () => false) {
   });
 
   // Failed modal: retry
-  document.getElementById('btn-puzzle-failed-retry')?.addEventListener('click', () => {
+  document.getElementById('btn-puzzle-failed-retry')?.addEventListener('click', (e) => {
+    if (refuseWhileProcessing(e.currentTarget)) return;
     document.getElementById('modal-puzzle-failed').classList.add('hidden');
     if (activePuzzle) startPuzzle(activePuzzle.id);
   });
 
-  // Failed modal: menu
+  // Failed modal: menu — unguarded for the same reason as btn-puzzle-menu.
   document.getElementById('btn-puzzle-failed-menu')?.addEventListener('click', () => {
     document.getElementById('modal-puzzle-failed').classList.add('hidden');
     clearActivePuzzle();

--- a/js/puzzles.js
+++ b/js/puzzles.js
@@ -72,7 +72,7 @@ export function decodePuzzleBoard(encoded, cols, rows) {
     if (c >= 0 && c < cols && r >= 0 && r < rows) {
       // Clamp colorIndex to valid range to guard against crafted share codes.
       // Special pieces (starflower/blackpearl) use colorIndex -1/-2 — those are fine.
-      const MAX_COLOR = 5; // PIECE_COLORS.length + EXTRA_COLORS.length
+      const MAX_COLOR = 5; // PIECE_COLORS.length
       if (colorIndex >= 0) colorIndex = Math.min(colorIndex, MAX_COLOR - 1);
       grid[c][r] = { colorIndex, special };
       if (bombTimer !== null) grid[c][r].bombTimer = bombTimer;

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -9,7 +9,7 @@
 import {
   GRID_COLS, GRID_ROWS, HEX_SIZE, PIECE_COLORS, STARFLOWER_COLOR, BLACK_PEARL_COLOR, GRAND_POOBAH_COLOR,
   FRAME_COLOR, BOARD_BG_COLOR,
-  HIGHLIGHT_COLOR, CLUSTER_HIGHLIGHT,
+  CLUSTER_HIGHLIGHT,
 } from './constants.js';
 import { hexToPixel, hexCorners } from './hex-math.js';
 import { getComboCount, getChainLevel } from './score.js';
@@ -235,10 +235,6 @@ export function spawnCreationParticles(cx, cy, count = 16) {
       hue: 190 + Math.random() * 40,  // cool steel-blue hues
     });
   }
-}
-
-export function clearCreationParticles() {
-  creationParticles = [];
 }
 
 // ─── Special Match Effect APIs ──────────────────────────────────

--- a/js/score.js
+++ b/js/score.js
@@ -60,9 +60,43 @@ export function resetChain() {
   comboCount = 0;
 }
 
-/** Animate the display score toward the actual score. Call each frame. */
+// ─── The score counter's clock ──────────────────────────────────
+//
+// The counter closes a share of the remaining gap each step, with a floor so
+// the last few points always land rather than converging forever. Both of
+// those used to be expressed *per frame* — `gap * 0.1` and `max(…, 1)` — and
+// `dt` was accepted and then ignored. So the counter's speed was whatever the
+// display's was: it ran at half speed on a 30 Hz panel and at double on a
+// 120 Hz one, and any frame the loop dropped was time the counter did not
+// count.
+//
+// The shape is kept and re-expressed against wall-clock time, calibrated so
+// that a 60 fps frame does exactly what it did before. One step of dt ms is
+// dt/16.667 of the old frame-steps: the geometric decay compounds over that
+// many frames, and the floor scales linearly with it.
+//
+// Substituting dt = 1000/60 gives frames = 1, hence gap * (1 - 0.9) = gap * 0.1
+// and a floor of 1 — the old expression exactly, so the feel at 60 fps is
+// unchanged rather than merely close.
+const REFERENCE_FRAME_MS  = 1000 / 60;
+const GAP_KEPT_PER_FRAME  = 0.9;  // 10% of the remaining gap closed per frame
+const MIN_POINTS_PER_FRAME = 1;
+
+/**
+ * Animate the display score toward the actual score. Call each frame.
+ * @param {number} dt — milliseconds since the previous frame.
+ */
 export function updateDisplayScore(dt) {
-  if (displayScore < score) {
-    displayScore = Math.min(score, displayScore + Math.max(1, (score - displayScore) * 0.1));
-  }
+  if (displayScore >= score) return;
+
+  // A non-finite or non-positive dt means no time passed that we can account
+  // for — the first frame after a park hands us exactly that (main.js resets
+  // lastTime to 0). Advancing on it would be inventing time.
+  const frames = (Number.isFinite(dt) && dt > 0) ? dt / REFERENCE_FRAME_MS : 0;
+  if (frames === 0) return;
+
+  const gap   = score - displayScore;
+  const eased = gap * (1 - Math.pow(GAP_KEPT_PER_FRAME, frames));
+  const floor = MIN_POINTS_PER_FRAME * frames;
+  displayScore = Math.min(score, displayScore + Math.max(floor, eased));
 }

--- a/js/specials.js
+++ b/js/specials.js
@@ -10,7 +10,7 @@
  *             Defused by including it in a 3+ match of the same color.
  */
 
-import { GRID_COLS, GRID_ROWS } from './constants.js';
+import { GRID_ROWS } from './constants.js';
 import { getNeighbors } from './hex-math.js';
 
 /** Derive actual grid bounds — puzzle grids may be smaller than GRID_COLS/GRID_ROWS. */
@@ -293,18 +293,5 @@ export function tickBombs(grid) {
     }
   }
   return expired;
-}
-
-/**
- * Count active bombs on the board.
- */
-export function countBombs(grid) {
-  let count = 0;
-  for (let c = 0; c < cols(grid); c++) {
-    for (let r = 0; r < rows(grid); r++) {
-      if (grid[c][r]?.special === 'bomb') count++;
-    }
-  }
-  return count;
 }
 

--- a/js/tween.js
+++ b/js/tween.js
@@ -86,9 +86,6 @@ export function hasActiveTweens() {
 // ─── Easing functions ───────────────────────────────────────────
 
 export function easeOutCubic(t) { return 1 - (1 - t) ** 3; }
-export function easeInOutCubic(t) {
-  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
-}
 export function easeOutBounce(t) {
   if (t < 1 / 2.75) return 7.5625 * t * t;
   if (t < 2 / 2.75) return 7.5625 * (t -= 1.5 / 2.75) * t + 0.75;

--- a/js/tween.js
+++ b/js/tween.js
@@ -11,6 +11,36 @@ import { wakeFrameLoop } from './frame.js';
 
 const active = [];
 
+// ─── The tween clock ────────────────────────────────────────────
+//
+// Tweens run off an accumulated clock, not the raw rAF timestamp. The wall
+// clock keeps running while frames do not: the loop parks itself on a settled
+// board (§6d), it parks behind an open modal, and the launcher cancels it
+// outright on suspend. A tween whose `start` is a raw timestamp counts that
+// whole dead interval as elapsed animation — open help mid-cascade and every
+// live tween snaps to its end state on the first frame back.
+//
+// So only time that actually passed *between rendered frames* is admitted.
+// Deliberate parks call suspendTweenClock(), which makes the first frame back
+// contribute nothing at all.
+
+let clock = 0;
+let lastFrame = -1;
+
+// Backstop for gaps nobody announced — a backgrounded tab is throttled by the
+// browser with none of our hooks firing. Longer than any frame a running game
+// produces, short enough that an unreported gap costs a blink rather than the
+// whole tween.
+const MAX_FRAME_MS = 250;
+
+/**
+ * The loop is stopping; the next frame is a fresh start however far off it is.
+ * Call from every deliberate park/suspend so the gap never reaches the tweens.
+ */
+export function suspendTweenClock() {
+  lastFrame = -1;
+}
+
 export function tween(durationMs, onUpdate, easing = easeOutCubic) {
   let resolve;
   const promise = new Promise(r => { resolve = r; });
@@ -30,11 +60,15 @@ export function tween(durationMs, onUpdate, easing = easeOutCubic) {
 
 /** Call once per frame from the game loop with the current timestamp. */
 export function updateTweens(now) {
+  if (lastFrame < 0) lastFrame = now;
+  clock += Math.max(0, Math.min(now - lastFrame, MAX_FRAME_MS));
+  lastFrame = now;
+
   for (let i = active.length - 1; i >= 0; i--) {
     const t = active[i];
     if (t.cancelled) { active.splice(i, 1); t.resolve(); continue; }
-    if (t.start < 0) t.start = now;
-    const elapsed = now - t.start;
+    if (t.start < 0) t.start = clock;
+    const elapsed = clock - t.start;
     const raw = t.duration > 0 ? Math.min(elapsed / t.duration, 1) : 1;
     const progress = t.easing(raw);
     t.onUpdate(progress);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,81 @@
+/**
+ * ui.js — the small DOM gestures that more than one module needs.
+ *
+ * Both helpers here existed twice, verbatim, in modules that cannot simply
+ * import one from the other: main.js imports animations.js and puzzle-mode.js,
+ * so neither of those can import main.js back. Copying was the path of least
+ * resistance, and it is how the two copies of the shake ended up with
+ * different null-handling and the two copies of the name prefill ended up
+ * maintained in parallel.
+ *
+ * DOM-only and main.js-free on purpose, like js/modal.js — nothing in here
+ * reaches for the game state, so it stays importable under `node --test`.
+ *
+ * This is a helpers module, not a UI layer. Rendering lives in renderer.js,
+ * gestures in input.js, modals in modal.js; something that belongs to one of
+ * those belongs there, not here.
+ */
+
+import { getPlayerName } from './storage.js';
+
+// ─── Refusal shake ──────────────────────────────────────────────
+
+/**
+ * Must match `.shake-animation`'s duration in css/overlays.css
+ * (`animation: shake 0.4s …`). Removing the class early would cut the
+ * animation off mid-shake.
+ */
+const SHAKE_MS = 400;
+
+/**
+ * Shake an element once to signal a refused action.
+ *
+ * Two call sites refuse a board-replacing click while the board is
+ * mid-animation — main.js's guardedAction() (new game, mode switch, the
+ * game-win and over-achiever restarts) and puzzle-mode.js's
+ * refuseWhileProcessing() (the puzzle selector, editor and restart buttons) —
+ * and both have to make the refusal read as deliberate rather than as a
+ * dropped tap.
+ *
+ * The sequence is not obvious and is easy to get subtly wrong, which is why
+ * one copy beats two: removing the class and re-adding it in the same task
+ * does nothing at all — the browser coalesces it and the animation never
+ * restarts — so the forced reflow in between is load-bearing, and the trailing
+ * removal is what leaves the element ready to shake again on the very next
+ * click.
+ *
+ * The guards themselves stay at the call sites: they answer to different
+ * busy-predicates (main.js owns the state machine; puzzle-mode.js has one
+ * injected) and want different return shapes. Only the gesture is shared.
+ *
+ * Safe to call with null — every caller reads its element out of an event.
+ * @param {Element|null|undefined} el
+ */
+export function shakeRefusal(el) {
+  if (!el || !el.classList) return;
+  el.classList.remove('shake-animation');
+  void el.offsetWidth; // force reflow, so re-adding the class restarts it
+  el.classList.add('shake-animation');
+  setTimeout(() => el.classList.remove('shake-animation'), SHAKE_MS);
+}
+
+// ─── Name entry ─────────────────────────────────────────────────
+
+/** Every modal that asks the player to sign a score. */
+const NAME_INPUT_IDS = ['go-name', 'gw-name', 'oa-name', 'es-name'];
+
+/**
+ * Prefill all four score-signing inputs with the sticky player name, so a
+ * returning player confirms rather than retypes.
+ *
+ * All four are filled every time rather than just the one modal about to open:
+ * the modals are static in index.html and any of them can be the next one
+ * shown, so which single id to touch is a question with no stable answer.
+ */
+export function prepopulateNameInputs() {
+  const name = getPlayerName();
+  for (const id of NAME_INPUT_IDS) {
+    const el = document.getElementById(id);
+    if (el) el.value = name;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hecknsic",
   "version": "1.2.33",
   "private": true,
+  "type": "module",
   "engines": {
     "node": ">=24"
   },

--- a/tests/cancellation.test.js
+++ b/tests/cancellation.test.js
@@ -1,0 +1,378 @@
+/**
+ * cancellation.test.js — a chain whose board is gone stops at its next seam
+ * (hecknsic#66).
+ *
+ * WHAT IS BEING PINNED
+ *
+ * Every animated move in this game is a chain of awaits that runs for a second
+ * or two, and the player can replace the board in the middle of it: restart,
+ * mode switch, puzzle load. The chain holds `ctx`, whose `grid` getter reads
+ * the machine's CURRENT board — so a chain that keeps going after a
+ * replacement does not write to a stale array harmlessly, it writes to the
+ * board the player is now looking at.
+ *
+ * The old defence was `boardGeneration !== gen` copied in after every await,
+ * twenty-five times, and two of them were missing (hecknsic#62). It is now one
+ * cancellation token per board (js/cancel.js), carried by the chain and
+ * cancelled when the board is replaced, with the check inside the awaits
+ * themselves.
+ *
+ * tests/rotation-cancel.test.js pins the individual animators against a
+ * hand-built context. These tests come at it from the other end: the real
+ * state machine, its real board, and the real board-replacing entry points, so
+ * what they exercise is the wiring — that the token minted for a rotation or a
+ * cascade is the one the replacement cancels.
+ *
+ * The harness is the one from tests/game-state.test.js: reducedMotion collapses
+ * every tween to zero duration, and pumping updateTweens() by hand plays the
+ * part the game loop's rAF callback normally plays. That is what makes
+ * "mid-flight" a deterministic moment rather than a race.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+installArcade({ powerSaver: false, reducedMotion: true });
+
+const store = new Map();
+Object.assign(globalThis.Arcade, {
+  state: {
+    get: (k) => store.get(k),
+    set: (k, v) => store.set(k, v),
+    remove: (k) => store.delete(k),
+    getOrInit: (k, d) => (store.has(k) ? store.get(k) : (store.set(k, d), d)),
+    migrate: () => {},
+  },
+  scores: { add() {}, list: () => [] },
+  stats: { update() {} },
+  player: { name: () => 'TESTER', setName() {} },
+});
+
+// ─── Fake DOM ───────────────────────────────────────────────────
+
+function fakeEl() {
+  return {
+    textContent: '', value: '', innerHTML: '',
+    style: {}, dataset: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    appendChild() {}, addEventListener() {}, removeEventListener() {},
+    querySelector: () => fakeEl(),
+    getBoundingClientRect: () => ({ width: 0, height: 0, top: 0, left: 0 }),
+  };
+}
+
+function makeCanvasCtx() {
+  const props = Object.create(null);
+  return new Proxy(Object.create(null), {
+    get(_t, prop) {
+      if (prop in props) return props[prop];
+      if (typeof prop === 'string' && /^create\w*Gradient$/.test(prop)) {
+        return () => ({ addColorStop() {} });
+      }
+      if (prop === 'measureText') return () => ({ width: 10 });
+      return () => {};
+    },
+    set(_t, prop, value) { props[prop] = value; return true; },
+  });
+}
+
+function makeCanvas(w = 1280, h = 720) {
+  const handlers = new Map();
+  return {
+    width: 0, height: 0,
+    handlers,
+    getContext: () => makeCanvasCtx(),
+    getBoundingClientRect: () => ({ width: w, height: h, top: 0, left: 0 }),
+    addEventListener: (type, fn) => { handlers.set(type, fn); },
+  };
+}
+
+globalThis.window = {
+  devicePixelRatio: 1,
+  matchMedia: () => ({ matches: true }),
+  requestAnimationFrame: () => 0,
+  addEventListener() {},
+};
+globalThis.document = {
+  documentElement: { style: { setProperty() {} } },
+  body: { classList: { toggle() {} } },
+  getElementById: (id) => (id === 'game-hud'
+    ? { getBoundingClientRect: () => ({ height: 60 }) }
+    : fakeEl()),
+  querySelector: () => fakeEl(),
+  querySelectorAll: () => [],
+  createElement: () => fakeEl(),
+  addEventListener() {},
+};
+globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame;
+
+// ─── Modules under test ─────────────────────────────────────────
+
+const { GRID_COLS, GRID_ROWS } = await import('../js/constants.js');
+const { getNeighbors, hexToPixel } = await import('../js/hex-math.js');
+const renderer = await import('../js/renderer.js');
+const input = await import('../js/input.js');
+const { updateTweens } = await import('../js/tween.js');
+const { setActiveGameMode } = await import('../js/modes.js');
+const cancel = await import('../js/cancel.js');
+const gs = await import('../js/game-state.js');
+
+const canvas = makeCanvas();
+renderer.initRenderer(canvas);
+renderer.resize(canvas);
+input.initInput(canvas);
+
+// ─── Harness ────────────────────────────────────────────────────
+
+/** One tick of the game loop's tween pump, plus a macrotask yield so the chain
+ *  can run on to whatever it awaits next (including real setTimeout delays). */
+let clock = 0;
+async function tick(times = 1) {
+  for (let i = 0; i < times; i++) {
+    updateTweens((clock += 16));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+/** Run a chain to settlement, or fail loudly if it never settles. */
+async function runOut(promise, { maxTicks = 4000 } = {}) {
+  let settled = false;
+  let error = null;
+  const p = promise.then(() => { settled = true; }, (e) => { settled = true; error = e; });
+  for (let i = 0; i < maxTicks && !settled; i++) await tick();
+  await p;
+  if (error) throw error;
+  assert.ok(settled, 'the chain never settled — a cancelled chain must not hang');
+}
+
+/** Colouring by row mod 3: no hex has a same-coloured pair of neighbours, so
+ *  nothing matches anywhere. */
+function quietBoard(cols = GRID_COLS, rows = GRID_ROWS) {
+  const g = [];
+  for (let c = 0; c < cols; c++) {
+    g[c] = [];
+    for (let r = 0; r < rows; r++) g[c][r] = { colorIndex: r % 3, special: null };
+  }
+  return g;
+}
+
+/** A board that will cascade: six identical neighbours around a different
+ *  centre is a starflower, and resolving it clears, drops and refills. */
+function starflowerBoard() {
+  const g = quietBoard();
+  g[4][4] = { colorIndex: 0, special: null };
+  for (const n of getNeighbors(4, 4)) g[n.col][n.row] = { colorIndex: 1, special: null };
+  return g;
+}
+
+const snapshot = (grid) =>
+  grid.map((col) => col.map((cell) => (cell ? { ...cell } : null)));
+
+function arm(board, mode = 'chill') {
+  setActiveGameMode(mode);
+  gs.resetGameStateForTests();
+  gs.setGrid(board);
+  gs.setState('selected');
+  renderer.setActiveGridSize(GRID_COLS, GRID_ROWS);
+}
+
+function clickHex(col, row) {
+  const { originX, originY } = renderer.getOrigin();
+  const p = hexToPixel(col, row, originX, originY);
+  const s = renderer.getBoardScale();
+  canvas.handlers.get('click')({ clientX: p.x * s, clientY: p.y * s, preventDefault() {} });
+}
+
+// ─── The token itself ───────────────────────────────────────────
+
+test('a live token lets work through; a cancelled one throws at every seam', async () => {
+  const token = cancel.createCancelToken(7);
+
+  assert.strictEqual(token.cancelled, false);
+  token.guard();                                   // must not throw
+
+  // A tween only advances when the loop pumps it, so start it, pump, then
+  // await — awaiting first would deadlock, here and in the real game.
+  const live = token.tween(10, () => {});
+  await tick();
+  await live;
+  await token.delay(0);
+
+  token.cancel();
+  assert.strictEqual(token.cancelled, true);
+
+  assert.throws(() => token.guard(), cancel.Cancelled,
+    'guard() is the seam for loop heads, where there is no await to hide in');
+
+  await assert.rejects(token.delay(0), cancel.Cancelled,
+    'a sleep that finishes on a board that is gone must not hand control back');
+
+  // The handler is attached before the pump that settles it, which is what
+  // every real caller does too — it is sitting in an `await`.
+  const tweening = assert.rejects(token.tween(10, () => {}), cancel.Cancelled,
+    'the tween seam is the one that replaces the twenty-five hand-written ' +
+    'generation comparisons — it has to throw, not resolve');
+  await tick();
+  await tweening;
+});
+
+test('catchCancelled swallows a cancellation and nothing else', async () => {
+  const token = cancel.cancelledToken(3);
+
+  assert.strictEqual(await cancel.catchCancelled(token.delay(0)), undefined,
+    'a chain stopping because its board was replaced is a normal outcome');
+
+  const boom = new TypeError('a real bug inside an animation');
+  await assert.rejects(
+    cancel.catchCancelled(Promise.reject(boom)), /a real bug/,
+    'anything that is not a Cancelled must still reach the console — an entry ' +
+    'point that swallows everything is how a broken animation goes unnoticed');
+});
+
+// ─── Rotation: the chain the state machine mints a token for ────
+
+test('a rotation whose board is replaced mid-flight never touches the replacement', async () => {
+  arm(quietBoard(), 'chill');
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+  assert.strictEqual(gs.getState(), 'selected', 'precondition: a cluster is selected');
+
+  const running = gs.animateRotation(true);
+  await tick();   // one await retired: the rotation is in flight
+
+  // What the player did: loaded a puzzle. loadPuzzleBoard() cancels the
+  // outgoing board's token and swaps the grid — and ctx.grid is a getter on
+  // the machine's live board, so an uncancelled rotation would commit its
+  // three remembered cells onto THIS grid.
+  const puzzle = quietBoard(5, 5);
+  const before = snapshot(puzzle);
+  gs.loadPuzzleBoard(puzzle, 5, 5);
+
+  await runOut(running);
+
+  assert.deepStrictEqual(snapshot(gs.getGrid()), before,
+    'the rotation committed to the puzzle board that replaced the one it ' +
+    'started on — the player watches a freshly loaded puzzle scramble itself');
+  assert.strictEqual(gs.getGrid(), puzzle, 'and the puzzle board is still the board');
+  assert.strictEqual(gs.getState(), 'idle',
+    'a cancelled rotation must not write the state either: loadPuzzleBoard ' +
+    "left the machine 'idle' and the stale chain has no business changing it");
+});
+
+// ─── Cascade: the longer chain, several animations deep ─────────
+
+test('a cascade whose board is replaced mid-flight never touches the replacement', async () => {
+  arm(starflowerBoard(), 'chill');
+
+  const running = gs.postRotationCheck(gs.getBoardGeneration());
+  await tick(3);   // into the starflower animation: flash, shrink, clear
+
+  // What the player did: hit New Game. resetGame() deals a fresh board and
+  // cancels the token the cascade is carrying.
+  gs.resetGame();
+  const fresh = gs.getGrid();
+  const before = snapshot(fresh);
+
+  await runOut(running);
+
+  assert.strictEqual(gs.getGrid(), fresh, 'the fresh board is still the board');
+  assert.deepStrictEqual(snapshot(fresh), before,
+    'the cascade went on clearing, dropping and refilling cells on the board ' +
+    'that replaced the one it started on');
+  assert.strictEqual(gs.getState(), 'idle',
+    "resetGame() left the machine 'idle'; the stale cascade must not put it " +
+    "back into 'cascading' or deselect on the new board's behalf");
+});
+
+test('a cascade left alone still cascades — the control for both tests above', async () => {
+  // Without this, the two tests above could pass because nothing ever runs.
+  arm(starflowerBoard(), 'chill');
+
+  await runOut(gs.postRotationCheck(gs.getBoardGeneration()));
+
+  const board = gs.getGrid();
+  let starflowers = 0;
+  for (let c = 0; c < GRID_COLS; c++) {
+    for (let r = 0; r < GRID_ROWS; r++) {
+      if (board[c]?.[r]?.special === 'starflower') starflowers++;
+    }
+  }
+  assert.ok(starflowers >= 1,
+    'the cascade must actually reach the board when nobody replaces it');
+});
+
+// ─── Repo gates ─────────────────────────────────────────────────
+
+/**
+ * Strip line and block comments, leaving string literals alone. Both gates
+ * below are about code: a comment that names the thing it is describing must
+ * not fail the rule it is describing.
+ */
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === '/' && d === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+    } else if (c === '/' && d === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+    } else if (c === '"' || c === "'" || c === '`') {
+      out += c; i++;
+      while (i < src.length && src[i] !== c) {
+        if (src[i] === '\\') { out += src[i]; i++; }
+        if (i < src.length) { out += src[i]; i++; }
+      }
+      out += c; i++;
+    } else {
+      out += c; i++;
+    }
+  }
+  return out;
+}
+
+test('animations.js reaches no DOM: no document. / window. outside comments', () => {
+  const code = stripComments(fs.readFileSync(path.join(ROOT, 'js', 'animations.js'), 'utf8'));
+
+  for (const token of ['document.', 'window.']) {
+    assert.ok(!code.includes(token),
+      `js/animations.js must not reference \`${token}\`. It used to write the ` +
+      'game-over and over-achiever modals from inside the explosion sequence, ' +
+      'which is how the end of a run ended up half-presentation and ' +
+      'half-animation, unreachable from a test and impossible to restyle ' +
+      'without touching an animation. Presentation goes through ' +
+      "game-state.js's host, which main.js registers (hecknsic#66).");
+  }
+});
+
+test('nothing compares board generations by hand any more', () => {
+  const files = fs.readdirSync(path.join(ROOT, 'js')).filter((f) => f.endsWith('.js'));
+  const violations = [];
+
+  for (const file of files) {
+    const code = stripComments(fs.readFileSync(path.join(ROOT, 'js', file), 'utf8'));
+    // The idiom: any equality test against a generation, however it is spelled
+    // (`ctx.boardGeneration !== gen`, `gen === boardGeneration`, …).
+    const idiom = /(?:\w+\.)?\b(?:boardGeneration|gen)\b\s*(?:!==?|===?)\s*(?:\w+\.)?\b(?:boardGeneration|gen)\b/g;
+    for (const m of code.matchAll(idiom)) {
+      violations.push(`js/${file}: ${m[0]}`);
+    }
+  }
+
+  assert.deepStrictEqual(violations, [],
+    'cancellation is a mechanism now, not a convention: the board carries a ' +
+    'token (js/cancel.js) and the check lives inside the awaits. A ' +
+    'hand-written generation comparison is the idiom #66 removed — it worked ' +
+    'only for as long as every author remembered it, and two of them did ' +
+    'not (#62):\n' + violations.join('\n'));
+});

--- a/tests/game-state.test.js
+++ b/tests/game-state.test.js
@@ -1,0 +1,622 @@
+/**
+ * game-state.test.js — the state machine, without a browser (hecknsic#65).
+ *
+ * The point of WP4 was never the file split; it was that the band every recent
+ * regression lived in had no test that could reach it. `idle` → `selected` →
+ * `rotating` → `cascading`, the cascade's priority ladder, the bomb rules and
+ * the game-over condition were all inside a module whose top level grabbed DOM
+ * nodes and booted the game on import, so `node --test` could not load it at
+ * all. js/game-state.js has no `document.` and no `window.` in it (the last
+ * test in this file is the gate on that), which is what makes everything below
+ * possible.
+ *
+ * WHAT THE HARNESS FAKES, AND WHY THAT IS HONEST
+ *
+ * The module under test is real, and so is everything it calls: board.js,
+ * specials.js, animations.js, score.js. Only the edges are stubbed — the
+ * launcher SDK, the canvas, and the document — and none of them carry game
+ * rules. In particular the animations are the real ones: `reducedMotion: true`
+ * collapses every tween to zero duration (js/tween.js), and pump() below plays
+ * the part the game loop normally plays by calling updateTweens(). That is the
+ * same trick tests/rotation-cancel.test.js uses.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// ─── Fake launcher SDK ──────────────────────────────────────────
+//
+// installArcade covers the settings surface; modes.js and storage.js also read
+// Arcade.state / .scores / .stats / .player. Deliberately NOT providing
+// Arcade.audio: js/audio.js feature-detects it and registers nothing without
+// it, so every play*() call in the machine is a documented no-op here.
+
+installArcade({ powerSaver: false, reducedMotion: true });
+
+const store = new Map();
+Object.assign(globalThis.Arcade, {
+  state: {
+    get: (k) => store.get(k),
+    set: (k, v) => store.set(k, v),
+    remove: (k) => store.delete(k),
+    getOrInit: (k, d) => (store.has(k) ? store.get(k) : (store.set(k, d), d)),
+    migrate: () => {},
+  },
+  scores: { add() {}, list: () => [] },
+  stats: { update() {} },
+  player: { name: () => 'TESTER', setName() {} },
+});
+
+// ─── Fake DOM ───────────────────────────────────────────────────
+//
+// Permissive on purpose. animations.js still writes the end-of-run modals
+// directly (moving that out is hecknsic#66), so handleGameOver() reaches for
+// `document.querySelector('#modal-gameover h2').style.color`. Returning a
+// live-ish element for every lookup keeps that path from throwing without
+// asserting anything about it.
+
+function fakeEl() {
+  return {
+    textContent: '', value: '', innerHTML: '',
+    style: {}, dataset: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    appendChild() {}, addEventListener() {}, removeEventListener() {},
+    querySelector: () => fakeEl(),
+    getBoundingClientRect: () => ({ width: 0, height: 0, top: 0, left: 0 }),
+  };
+}
+
+const canvasOps = [];
+function makeCtx() {
+  const props = Object.create(null);
+  return new Proxy(Object.create(null), {
+    get(_t, prop) {
+      if (prop in props) return props[prop];
+      if (typeof prop === 'string' && /^create\w*Gradient$/.test(prop)) {
+        return () => ({ addColorStop() {} });
+      }
+      if (prop === 'measureText') return () => ({ width: 10 });
+      return (...args) => { canvasOps.push({ op: prop, args }); };
+    },
+    set(_t, prop, value) { props[prop] = value; return true; },
+  });
+}
+
+function makeCanvas(w = 1280, h = 720) {
+  const handlers = new Map();
+  return {
+    width: 0, height: 0,
+    handlers,
+    getContext: () => makeCtx(),
+    getBoundingClientRect: () => ({ width: w, height: h, top: 0, left: 0 }),
+    addEventListener: (type, fn) => { handlers.set(type, fn); },
+  };
+}
+
+globalThis.window = {
+  devicePixelRatio: 1,
+  matchMedia: () => ({ matches: true }),
+  requestAnimationFrame: () => 0,
+  addEventListener() {},
+};
+globalThis.document = {
+  documentElement: { style: { setProperty() {} } },
+  body: { classList: { toggle() {} } },
+  getElementById: (id) => (id === 'game-hud'
+    ? { getBoundingClientRect: () => ({ height: 60 }) }
+    : fakeEl()),
+  querySelector: () => fakeEl(),
+  querySelectorAll: () => [],
+  createElement: () => fakeEl(),
+  addEventListener() {},
+};
+globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame;
+
+// ─── Modules under test ─────────────────────────────────────────
+
+const { GRID_COLS, GRID_ROWS, BOMB_INITIAL_TIMER } = await import('../js/constants.js');
+const { findMatchesForMode } = await import('../js/board.js');
+const { getNeighbors, hexToPixel } = await import('../js/hex-math.js');
+const renderer = await import('../js/renderer.js');
+const input = await import('../js/input.js');
+const { updateTweens } = await import('../js/tween.js');
+const { setActiveGameMode } = await import('../js/modes.js');
+const gs = await import('../js/game-state.js');
+
+const canvas = makeCanvas();
+renderer.initRenderer(canvas);
+// resize() is what computes the grid origin and the board scale; without it
+// getOrigin() is {undefined, undefined} and every pixel→hex lookup is NaN.
+renderer.resize(canvas);
+input.initInput(canvas);
+
+// ─── Harness helpers ────────────────────────────────────────────
+
+/**
+ * Play the game loop's part for one async chain.
+ *
+ * Tweens only advance when updateTweens() is called, which in the real game is
+ * the rAF callback. reducedMotion makes each tween zero-duration, so one pump
+ * tick retires one await; the setTimeout(0) yield is what lets animations.js's
+ * `delay(100)` (a real timer) fire between cascade steps.
+ */
+async function pump(promise, { maxTicks = 4000 } = {}) {
+  let settled = false;
+  let error = null;
+  const p = promise.then(() => { settled = true; }, (e) => { settled = true; error = e; });
+  let t = 0;
+  for (let i = 0; i < maxTicks && !settled; i++) {
+    updateTweens((t += 16));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  await p;
+  if (error) throw error;
+  assert.ok(settled, 'chain did not settle within the pump budget');
+}
+
+/** A board with no matches and no special formations anywhere on it.
+ *  Colouring by row mod 3: every hex neighbour sits on an adjacent row, so no
+ *  monochrome triangle can form. The `stable` precondition test below proves it
+ *  rather than trusting it. */
+function quietBoard(cols = GRID_COLS, rows = GRID_ROWS) {
+  const g = [];
+  for (let c = 0; c < cols; c++) {
+    g[c] = [];
+    for (let r = 0; r < rows; r++) g[c][r] = { colorIndex: r % 3, special: null };
+  }
+  return g;
+}
+
+/** A board with exactly one monochrome triangle on an otherwise quiet field. */
+function boardWithOneMatch() {
+  const g = quietBoard();
+  // (4,4) and two mutually-adjacent neighbours of it.
+  const [a, b] = getNeighbors(4, 4);
+  const color = g[4][4].colorIndex;
+  g[a.col][a.row] = { colorIndex: color, special: null };
+  g[b.col][b.row] = { colorIndex: color, special: null };
+  return g;
+}
+
+/** Put the machine in a known state on a given board, in `mode`. */
+function arm(board, mode = 'arcade', { moveCount = 0 } = {}) {
+  setActiveGameMode(mode);
+  gs.resetGameStateForTests();
+  gs.setGrid(board);
+  gs.setMoveCount(moveCount);
+  gs.setState('selected');
+  renderer.setActiveGridSize(GRID_COLS, GRID_ROWS);
+}
+
+/** Click the canvas at a hex's centre and let the machine answer it. */
+function clickHex(col, row) {
+  const { originX, originY } = renderer.getOrigin();
+  const p = hexToPixel(col, row, originX, originY);
+  const s = renderer.getBoardScale();
+  canvas.handlers.get('click')({
+    clientX: p.x * s, clientY: p.y * s, preventDefault() {},
+  });
+}
+
+// ─── Preconditions ──────────────────────────────────────────────
+
+test('harness: the quiet board really is quiet', () => {
+  const g = quietBoard();
+  assert.strictEqual(findMatchesForMode(g, GRID_COLS, GRID_ROWS).size, 0);
+  assert.strictEqual(gs.nextResolution(g, GRID_COLS, GRID_ROWS).kind, 'stable');
+});
+
+test('harness: the one-match board has a match and nothing above it on the ladder', () => {
+  const g = boardWithOneMatch();
+  assert.ok(findMatchesForMode(g, GRID_COLS, GRID_ROWS).size >= 3);
+  assert.strictEqual(gs.nextResolution(g, GRID_COLS, GRID_ROWS).kind, 'match');
+});
+
+test('nothingLeftToDo refuses to park while the board is mid-animation', () => {
+  input.clearPendingAction();
+  renderer.clearDirty();
+  gs.setState('idle');
+  assert.strictEqual(gs.nothingLeftToDo(), true, 'settled board: the loop may park');
+
+  gs.setState('cascading');
+  assert.strictEqual(gs.nothingLeftToDo(), false,
+    'a cascade awaits between tweens, so there are frames with nothing dirty — ' +
+    'parking there would strand the chain on a stopped loop');
+
+  gs.setState('idle');
+  input.triggerAction('rotateCW');
+  assert.strictEqual(gs.nothingLeftToDo(), false, 'a queued gesture still needs answering');
+  input.clearPendingAction();
+  renderer.clearDirty();
+});
+
+// ─── Selection transitions ──────────────────────────────────────
+
+test('idle + click on a plain hex → selected, with a 3-hex cluster', async () => {
+  arm(quietBoard());
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+
+  assert.strictEqual(gs.getState(), 'selected');
+  const cluster = gs.getSelectedCluster();
+  assert.strictEqual(cluster.length, 3);
+  assert.ok(cluster.some((h) => h.col === 4 && h.row === 4),
+    'the clicked hex is part of the selected cluster');
+  assert.strictEqual(gs.getFlowerCenter(), null);
+  assert.strictEqual(gs.getPearlCenter(), null);
+});
+
+test('clicking the same cluster again deselects', async () => {
+  arm(quietBoard());
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+  const first = gs.getSelectedCluster();
+  assert.ok(first);
+
+  // Same pixel → same cluster → deselect.
+  clickHex(4, 4);
+  gs.processInput();
+  assert.strictEqual(gs.getState(), 'idle');
+  assert.strictEqual(gs.getSelectedCluster(), null);
+});
+
+test('clicking a different cluster stays selected and swaps the selection', async () => {
+  arm(quietBoard());
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+  const first = gs.getSelectedCluster();
+
+  clickHex(1, 1);
+  gs.processInput();
+  assert.strictEqual(gs.getState(), 'selected');
+  assert.ok(!gs.clustersMatch(gs.getSelectedCluster(), first),
+    'a click on a different cluster replaces the selection rather than clearing it');
+});
+
+test('clicking a starflower selects the whole ring; clicking a black pearl selects the Y', async () => {
+  const g = quietBoard();
+  g[4][4] = { colorIndex: -1, special: 'starflower' };
+  arm(g);
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+
+  assert.strictEqual(gs.getState(), 'selected');
+  assert.deepStrictEqual(gs.getFlowerCenter(), { col: 4, row: 4 });
+  assert.strictEqual(gs.getPearlCenter(), null);
+  assert.strictEqual(gs.getSelectedCluster().length, 7, 'centre + 6 ring hexes');
+
+  const g2 = quietBoard();
+  g2[4][4] = { colorIndex: -2, special: 'blackpearl' };
+  arm(g2);
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+
+  assert.strictEqual(gs.getState(), 'selected');
+  assert.deepStrictEqual(gs.getPearlCenter(), { col: 4, row: 4 });
+  assert.strictEqual(gs.getFlowerCenter(), null);
+  assert.strictEqual(gs.getSelectedCluster().length, 4, 'centre + 3 alternating hexes');
+});
+
+test("'rotating' and 'cascading' do not consume the queued gesture", () => {
+  arm(quietBoard());
+  for (const busy of ['rotating', 'cascading']) {
+    gs.setState(busy);
+    input.triggerAction('rotateCW');
+    gs.processInput();
+    assert.ok(input.hasPendingAction(),
+      `${busy} must leave the gesture queued for the frame after it settles`);
+    assert.strictEqual(gs.getState(), busy);
+  }
+  input.clearPendingAction();
+});
+
+// ─── Rotation outcome: retain vs. deselect ──────────────────────
+
+test('a rotation that produces nothing retains the selection', async () => {
+  arm(quietBoard());
+  gs.setState('idle');
+  clickHex(4, 4);
+  gs.processInput();
+  const cluster = gs.getSelectedCluster();
+  assert.ok(cluster, 'precondition: something is selected');
+
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+
+  assert.strictEqual(gs.getState(), 'selected',
+    'nothing cleared, so the player keeps the cluster and can turn it again');
+  assert.ok(gs.clustersMatch(gs.getSelectedCluster(), cluster));
+});
+
+test('a rotation that produces a match deselects and returns to idle', async () => {
+  arm(boardWithOneMatch());
+  gs.setState('idle');
+  clickHex(0, 0);
+  gs.processInput();
+  assert.ok(gs.getSelectedCluster(), 'precondition: something is selected');
+
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+
+  assert.strictEqual(gs.getState(), 'idle');
+  assert.strictEqual(gs.getSelectedCluster(), null);
+  assert.strictEqual(gs.getFlowerCenter(), null);
+  assert.strictEqual(gs.getPearlCenter(), null);
+});
+
+// ─── Cascade resolution ordering ────────────────────────────────
+//
+// The ladder is poobah ring > poobah > pearl > starflower > match, and the
+// order is load-bearing rather than arbitrary: the formations are built out of
+// each other, so resolving a plain match first would clear the tiles a larger
+// formation is standing on.
+
+/** Neighbours of (4,4). */
+const RING = getNeighbors(4, 4);
+
+function ringOf(special, colorIndex) {
+  const g = boardWithOneMatch();   // a plain match is present throughout
+  for (const n of RING) g[n.col][n.row] = { colorIndex, special };
+  return g;
+}
+
+test('ordering: a Grand Poobah ring outranks everything below it', () => {
+  const g = ringOf('grandpoobah', -3);
+  assert.strictEqual(gs.nextResolution(g, GRID_COLS, GRID_ROWS).kind, 'poobah-ring');
+});
+
+test('ordering: Grand Poobahs outrank pearls, starflowers and matches', () => {
+  const g = ringOf('blackpearl', -2);
+  // The pearl ring is simultaneously a black-pearl formation's worth of
+  // specials and a plain-match board; the poobah must win.
+  assert.strictEqual(gs.nextResolution(g, GRID_COLS, GRID_ROWS).kind, 'grandpoobah');
+});
+
+test('ordering: black pearls outrank starflowers and matches', () => {
+  const g = ringOf('starflower', -1);
+  assert.strictEqual(gs.nextResolution(g, GRID_COLS, GRID_ROWS).kind, 'blackpearl');
+});
+
+test('ordering: starflowers outrank plain matches', () => {
+  const g = boardWithOneMatch();
+  // Six identical neighbours around a differently-coloured centre.
+  g[4][4] = { colorIndex: 0, special: null };
+  for (const n of RING) g[n.col][n.row] = { colorIndex: 1, special: null };
+  assert.strictEqual(gs.nextResolution(g, GRID_COLS, GRID_ROWS).kind, 'starflower');
+});
+
+test('ordering: a plain match is the last rung, and a quiet board is stable', () => {
+  assert.strictEqual(gs.nextResolution(boardWithOneMatch(), GRID_COLS, GRID_ROWS).kind, 'match');
+  assert.strictEqual(gs.nextResolution(quietBoard(), GRID_COLS, GRID_ROWS).kind, 'stable');
+});
+
+test('the over-achiever ring ends the run without cascading', async () => {
+  arm(ringOf('grandpoobah', -3));
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getState(), 'gameover',
+    'the poobah-ring branch returns straight out of postRotationCheck');
+});
+
+test('a cascade actually runs the ladder: a starflower board ends up holding one', async () => {
+  const g = quietBoard();
+  g[4][4] = { colorIndex: 0, special: null };
+  for (const n of RING) g[n.col][n.row] = { colorIndex: 1, special: null };
+  arm(g, 'chill');   // chill has no bombs and no game-over to interfere
+
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+
+  const board = gs.getGrid();
+  let starflowers = 0;
+  for (let c = 0; c < GRID_COLS; c++) {
+    for (let r = 0; r < GRID_ROWS; r++) {
+      if (board[c]?.[r]?.special === 'starflower') starflowers++;
+    }
+  }
+  assert.ok(starflowers >= 1, 'the starflower rung created a starflower on the board');
+  assert.strictEqual(gs.getState(), 'idle', 'something cleared, so the selection is dropped');
+});
+
+// ─── Bomb rules, gated by the mode flags ────────────────────────
+//
+// modes.js: arcade { hasBombs: true, ticksBombs: true }, chill { both false },
+// puzzle { ticksBombs: true, hasBombs: false } — puzzles use pre-placed bombs
+// and must never grow new ones.
+
+function boardWithBomb(timer) {
+  const g = quietBoard();
+  g[0][0] = { colorIndex: 0, special: 'bomb', bombTimer: timer };
+  return g;
+}
+
+test('arcade ticks the fuse on every move', async () => {
+  arm(boardWithBomb(5), 'arcade');
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getGrid()[0][0].bombTimer, 4);
+});
+
+test('puzzle ticks the fuse too — pre-placed bombs are the puzzle', async () => {
+  arm(boardWithBomb(5), 'puzzle');
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getGrid()[0][0].bombTimer, 4);
+});
+
+test('chill never ticks a fuse', async () => {
+  arm(boardWithBomb(5), 'chill');
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getGrid()[0][0].bombTimer, 5);
+});
+
+test('arcade queues a new bomb on the spawn interval; puzzle and chill never do', async () => {
+  // dynamicInterval is 15 at score 0, so the 15th move is a spawn move.
+  arm(quietBoard(), 'arcade', { moveCount: 14 });
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getBombQueued(), true, 'arcade hasBombs → a bomb is queued');
+
+  arm(quietBoard(), 'puzzle', { moveCount: 14 });
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getBombQueued(), false,
+    'puzzle ticksBombs but does NOT hasBombs — pre-placed only');
+
+  arm(quietBoard(), 'chill', { moveCount: 14 });
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getBombQueued(), false, 'chill has neither flag');
+});
+
+test('an arcade move that is not on the interval queues nothing', async () => {
+  arm(quietBoard(), 'arcade', { moveCount: 0 });
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getBombQueued(), false);
+});
+
+// ─── Game over ──────────────────────────────────────────────────
+
+test('an expired bomb ends the game in arcade', async () => {
+  arm(boardWithBomb(1), 'arcade');
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getGrid()[0][0], null,
+    'handleGameOver blew the board apart, so the cells are cleared');
+  assert.strictEqual(gs.getState(), 'gameover');
+});
+
+test('an expired bomb ends the game in puzzle mode too (hasGameOver)', async () => {
+  arm(boardWithBomb(1), 'puzzle');
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getState(), 'gameover');
+});
+
+test('a live fuse does not end the game', async () => {
+  arm(boardWithBomb(5), 'arcade');
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+  assert.strictEqual(gs.getState(), 'selected', 'nothing cleared, selection retained');
+});
+
+// ─── Bomb urgency ───────────────────────────────────────────────
+
+test('bombUrgency reads the shortest live fuse, and is 0 on a clear board', () => {
+  arm(quietBoard(), 'arcade');
+  assert.strictEqual(gs.bombUrgency(), 0);
+
+  const g = quietBoard();
+  g[0][0] = { colorIndex: 0, special: 'bomb', bombTimer: BOMB_INITIAL_TIMER + 1 };
+  g[1][0] = { colorIndex: 0, special: 'bomb', bombTimer: 1 };
+  arm(g, 'arcade');
+  assert.strictEqual(gs.bombUrgency(), 1, 'the fuse about to end the game is the one that counts');
+});
+
+// ─── Board lifetime ─────────────────────────────────────────────
+
+test('resetGame deals a fresh board, bumps the generation and clears the selection', () => {
+  arm(boardWithOneMatch(), 'arcade', { moveCount: 7 });
+  gs.setBombQueued(true);
+  const before = gs.getBoardGeneration();
+
+  gs.resetGame();
+
+  assert.strictEqual(gs.getBoardGeneration(), before + 1,
+    'the bump is what makes an in-flight rotation bail out at its next check');
+  assert.strictEqual(gs.getState(), 'idle');
+  assert.strictEqual(gs.getMoveCount(), 0);
+  assert.strictEqual(gs.getBombQueued(), false);
+  assert.strictEqual(gs.getSelectedCluster(), null);
+  assert.strictEqual(gs.getActiveCols(), GRID_COLS);
+  assert.strictEqual(gs.getActiveRows(), GRID_ROWS);
+});
+
+test('loadPuzzleBoard adopts the puzzle grid, its size, and the puzzle mode', () => {
+  arm(quietBoard(), 'arcade', { moveCount: 3 });
+  const before = gs.getBoardGeneration();
+  const puzzle = quietBoard(5, 5);
+
+  gs.loadPuzzleBoard(puzzle, 5, 5);
+
+  assert.strictEqual(gs.getBoardGeneration(), before + 1);
+  assert.strictEqual(gs.getGrid(), puzzle);
+  assert.strictEqual(gs.getActiveCols(), 5);
+  assert.strictEqual(gs.getActiveRows(), 5);
+  assert.strictEqual(gs.getMoveCount(), 0);
+  assert.strictEqual(gs.getState(), 'idle');
+
+  renderer.setActiveGridSize(GRID_COLS, GRID_ROWS);   // put the renderer back
+});
+
+test('resumeFromPause clears the pause and resets the host frame clock', () => {
+  let frameClockResets = 0;
+  gs.registerGameStateHost({ resetFrameClock: () => { frameClockResets++; } });
+  gs.setPaused(true);
+  assert.strictEqual(gs.isGamePaused(), true);
+
+  gs.resumeFromPause();
+
+  assert.strictEqual(gs.isGamePaused(), false);
+  assert.strictEqual(frameClockResets, 1,
+    'a modal that was open for a minute must not hand the score counter a 60s delta');
+  gs.registerGameStateHost({});
+});
+
+test('isProcessing is true exactly in the two animating states', () => {
+  for (const s of ['rotating', 'cascading']) {
+    gs.setState(s);
+    assert.strictEqual(gs.isProcessing(), true, s);
+  }
+  for (const s of ['idle', 'selected', 'gameover']) {
+    gs.setState(s);
+    assert.strictEqual(gs.isProcessing(), false, s);
+  }
+});
+
+// ─── Repo gate ──────────────────────────────────────────────────
+
+test('game-state.js reaches no DOM: no document. / window. outside comments', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js', 'game-state.js'), 'utf8');
+  const code = stripComments(src);
+
+  for (const token of ['document.', 'window.']) {
+    assert.ok(!code.includes(token),
+      `js/game-state.js must not reference \`${token}\` — the whole point of the ` +
+      `module is that it runs under node. UI effects go through the host ` +
+      `(registerGameStateHost) or through a node-safe seam like js/modal.js.`);
+  }
+});
+
+/**
+ * Strip line and block comments, leaving string literals alone.
+ *
+ * The gate has to ignore comments or the module's own header — which says in
+ * so many words that it contains no `document.` — would fail it. Regex
+ * literals are not tracked; game-state.js has none, and a future one would
+ * only ever cause a false *pass*, never a false failure.
+ */
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === '/' && d === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+    } else if (c === '/' && d === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+    } else if (c === '"' || c === "'" || c === '`') {
+      out += c; i++;
+      while (i < src.length && src[i] !== c) {
+        if (src[i] === '\\') { out += src[i]; i++; }
+        if (i < src.length) { out += src[i]; i++; }
+      }
+      out += c; i++;
+    } else {
+      out += c; i++;
+    }
+  }
+  return out;
+}

--- a/tests/game-state.test.js
+++ b/tests/game-state.test.js
@@ -425,6 +425,54 @@ test('a cascade actually runs the ladder: a starflower board ends up holding one
   assert.strictEqual(gs.getState(), 'idle', 'something cleared, so the selection is dropped');
 });
 
+test('the refill consumes the queued bomb — the rule the animation used to own', async () => {
+  // fillEmpty()'s bomb argument and the `bombQueued = false` that follows a
+  // successful refill used to be four hand-copied pairs inside animations.js,
+  // reached through ctx.setBombQueued(). hecknsic#66 moved the rule to
+  // game-state.js's settleBoard(); this is that rule, asserted end to end.
+  const g = quietBoard();
+  g[4][4] = { colorIndex: 0, special: null };
+  for (const n of RING) g[n.col][n.row] = { colorIndex: 1, special: null };
+  arm(g, 'arcade');
+  gs.setBombQueued(true);
+
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+
+  // The queue flag is the whole assertion, and it is not a vacuous one: it can
+  // only clear if the refill actually dealt tiles, which is the condition the
+  // rule is written against. Counting bombs on the board afterwards would be
+  // flaky rather than stronger — the refill deals random colours, so a chained
+  // cascade step can clear the very bomb it just dropped in.
+  assert.strictEqual(gs.getBombQueued(), false,
+    'a refill that dealt tiles must consume the queued bomb, or the next ' +
+    'refill deals a second bomb for the same move');
+});
+
+test('building a Grand Poobah fires the win transition exactly once', async () => {
+  // The win used to be the last statement of animateGrandPoobahCreation(),
+  // made through the context; it is the caller's now (hecknsic#66). Same
+  // moment, same count.
+  const g = quietBoard();
+  for (const n of RING) g[n.col][n.row] = { colorIndex: -2, special: 'blackpearl' };
+  arm(g, 'chill');
+  let wins = 0;
+  gs.registerGameStateHost({ onGameWin: () => { wins++; } });
+
+  await pump(gs.postRotationCheck(gs.getBoardGeneration()));
+
+  gs.registerGameStateHost({});
+  assert.strictEqual(wins, 1, 'six black pearls make a Grand Poobah, and that wins the game');
+
+  const board = gs.getGrid();
+  let poobahs = 0;
+  for (let c = 0; c < GRID_COLS; c++) {
+    for (let r = 0; r < GRID_ROWS; r++) {
+      if (board[c]?.[r]?.special === 'grandpoobah') poobahs++;
+    }
+  }
+  assert.ok(poobahs >= 1, 'and the poobah is on the board');
+});
+
 // ─── Bomb rules, gated by the mode flags ────────────────────────
 //
 // modes.js: arcade { hasBombs: true, ticksBombs: true }, chill { both false },

--- a/tests/modal-seam.test.js
+++ b/tests/modal-seam.test.js
@@ -1,0 +1,354 @@
+/**
+ * modal-seam.test.js — one way in and out of a modal (hecknsic#64).
+ *
+ * The bug this pins is not subtle once you see it: main.js's modals paused the
+ * game, the puzzle selector / result / failed / editor modals did not, and
+ * nothing anywhere enforced either convention. The board went on animating and
+ * consuming clicks behind half the modals in the game, and #57 had already had
+ * to fix six handlers that cleared the pause flag without waking the loop it
+ * had parked. Both failures are call-site failures — the sequence was written
+ * out by hand eleven times — so the fix is a seam, and these tests hold the
+ * seam's contract rather than any one call site's.
+ *
+ * What is asserted here:
+ *   - opening a modal pauses (per the documented policy table);
+ *   - closing resumes, and resumes *through the loop's own wake seam*, which
+ *     is what "a parked loop does not restart because a flag flipped" means;
+ *   - a redraw requested behind an open modal does NOT put frames back on the
+ *     schedule — the gate registered in main.js stays the sole authority;
+ *   - closing always clears the pending action (ghost-click protection);
+ *   - the three end-of-game modals are non-pausing on purpose, because the
+ *     explosion tween runs behind them and needs a live loop;
+ *   - and two repo gates: nothing outside js/modal.js toggles `hidden` on a
+ *     modal root, and every modal root in index.html has a policy.
+ *
+ * The document stub is the same trick tests/rotation-cancel.test.js uses; the
+ * loop stub is the one from tests/power-saver.test.js. Arcade has to be
+ * installed before the module graph is evaluated (js/tween.js reads
+ * reducedMotion at call time and frame.js comes along with it).
+ */
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+installArcade({ powerSaver: false, reducedMotion: true });
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// ─── DOM stub ───────────────────────────────────────────────────
+//
+// Just enough of an element to observe the one thing the seam does to the DOM.
+
+const elements = new Map();
+
+function fakeElement(id) {
+  const classes = new Set(['modal', 'hidden']);
+  return {
+    id,
+    classList: {
+      add: (c) => classes.add(c),
+      remove: (c) => classes.delete(c),
+      toggle: (c, on) => (on ? classes.add(c) : classes.delete(c)),
+      contains: (c) => classes.has(c),
+    },
+  };
+}
+
+globalThis.window = {
+  devicePixelRatio: 1,
+  matchMedia: () => ({ matches: true }),
+  requestAnimationFrame: () => 0,
+};
+globalThis.document = {
+  documentElement: { style: { setProperty() {} } },
+  getElementById: (id) => elements.get(id) ?? null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame;
+
+const modal    = await import('../js/modal.js');
+const frame    = await import('../js/frame.js');
+const renderer = await import('../js/renderer.js');
+const input    = await import('../js/input.js');
+
+for (const id of modal.MODAL_IDS) elements.set(id, fakeElement(id));
+
+const isHidden = (id) => elements.get(id).classList.contains('hidden');
+
+/**
+ * A stand-in for main.js: the pause flag, resumeFromPause(), the frame loop,
+ * and — critically — the same gate main.js registers at the bottom of its
+ * bootstrap. Everything the seam is allowed to touch, it touches through here.
+ */
+function makeHost() {
+  const h = {
+    isPaused: false,
+    running: true,
+    starts: 0,
+    resumes: 0,
+  };
+
+  frame.registerFrameLoop(
+    { start() { h.running = true; h.starts++; }, running: () => h.running },
+    () => !h.isPaused,          // js/main.js:634 — the sole authority
+  );
+
+  modal.resetModalSeam();
+  modal.registerModalHost({
+    pause: () => { h.isPaused = true; },
+    resume: () => {                 // js/main.js resumeFromPause()
+      h.resumes++;
+      h.isPaused = false;
+      frame.wakeFrameLoop();
+    },
+  });
+
+  // Every modal root back to hidden, and the loop parked as it would be behind
+  // one (gameLoop parks on the first frame that observes the pause).
+  for (const id of modal.MODAL_IDS) elements.get(id).classList.add('hidden');
+  input.clearPendingAction();
+  h.running = false;
+  h.starts = 0;
+  h.resumes = 0;
+  return h;
+}
+
+// ─── Open / close ───────────────────────────────────────────────
+
+test('opening a pausing modal hides nothing else and parks the game', () => {
+  const h = makeHost();
+
+  modal.openModal('modal-help');
+
+  assert.strictEqual(isHidden('modal-help'), false, 'the modal root must be shown');
+  assert.strictEqual(h.isPaused, true,
+    'opening a modal must pause the game — the board must not animate or eat ' +
+    'input behind it');
+  assert.strictEqual(modal.isModalOpen('modal-help'), true);
+});
+
+test('closing resumes through the wake seam, not by flipping a flag', () => {
+  const h = makeHost();
+
+  modal.openModal('modal-help');
+  assert.strictEqual(h.starts, 0, 'precondition: the loop is parked behind the modal');
+
+  modal.closeModal('modal-help');
+
+  assert.strictEqual(isHidden('modal-help'), true, 'the modal root must be hidden again');
+  assert.strictEqual(h.isPaused, false, 'the pause must be lifted');
+  assert.strictEqual(h.starts, 1,
+    'clearing the flag is not enough (#55/#57): a parked loop does not restart ' +
+    'because a boolean flipped, so the close must wake it as well — otherwise ' +
+    'the board sits frozen until the next resize');
+  assert.strictEqual(modal.isModalOpen('modal-help'), false);
+});
+
+test('closing discards the click that dismissed the modal', () => {
+  const h = makeHost();
+
+  modal.openModal('modal-scores');
+  input.triggerAction('rotateCW');   // a gesture that landed behind the modal
+  assert.strictEqual(input.hasPendingAction(), true, 'precondition: queued');
+
+  modal.closeModal('modal-scores');
+
+  assert.strictEqual(input.hasPendingAction(), false,
+    'the seam must clear the pending action on close (js/input.js) — a ghost ' +
+    'click surviving the close is answered by the board on the next frame');
+});
+
+// ─── The gate stays the sole authority ──────────────────────────
+
+test('a redraw requested behind an open modal does not restart the loop', () => {
+  const h = makeHost();
+
+  modal.openModal('modal-puzzle-select');
+  assert.strictEqual(h.isPaused, true, 'precondition: the selector pauses');
+
+  renderer.requestRedraw();
+  assert.strictEqual(h.starts, 0,
+    'requestRedraw() must not revive the loop behind a modal — that is a ' +
+    'deliberate park, not an idle one, and the gate registered in main.js is ' +
+    'what tells the two apart');
+
+  input.triggerAction('rotateCW');   // the keypress path: queue + requestRedraw
+  assert.strictEqual(h.starts, 0,
+    'a keypress behind an open modal must not put frames back on the schedule; ' +
+    'the seam must not add a second path that starts the loop');
+
+  modal.closeModal('modal-puzzle-select');
+  assert.strictEqual(h.starts, 1, 'and the close is what brings it back');
+});
+
+// ─── Policy ─────────────────────────────────────────────────────
+
+test('the puzzle modals opened on a live board pause — the bug in #64', () => {
+  for (const id of ['modal-puzzle-select', 'modal-puzzle-editor']) {
+    const h = makeHost();
+    modal.openModal(id);
+    assert.strictEqual(h.isPaused, true,
+      `${id} must pause: before the seam it never touched the pause flag at ` +
+      'all, so the board kept animating and consuming input behind it');
+    modal.closeModal(id);
+    assert.strictEqual(h.isPaused, false, `${id} must resume on close`);
+    assert.strictEqual(h.starts, 1, `${id} must wake the loop on close`);
+  }
+});
+
+test('the end-of-run modals stay non-pausing so the explosion can tick', () => {
+  // The two puzzle end-of-run modals belong in this list, not with the puzzle
+  // modals that open on a live board. Both fire _onPuzzleEnd() as they open,
+  // which sets state = 'gameover' — input is already refused, so the pause buys
+  // nothing — and both are opened from a setTimeout(600) inside onPuzzleMove().
+  // Solve a puzzle on the same move a pre-placed bomb expires and that timer
+  // lands 600 ms into handleGameOver()'s 1500 ms explosion; pausing there would
+  // freeze the board mid-detonation until the player dismissed the modal.
+  for (const id of ['modal-gameover', 'modal-gamewin', 'modal-over-achiever',
+                    'modal-puzzle-result', 'modal-puzzle-failed']) {
+    const h = makeHost();
+    modal.openModal(id);
+    assert.strictEqual(h.isPaused, false,
+      `${id} must NOT pause: handleGameOver()/handleOverAchiever() show it and ` +
+      'then await a 1.5 s tween that blows the board apart behind it, and ' +
+      'handleGameWin() is the tail of an animation its caller is still ' +
+      'awaiting. Pausing would park the loop those awaits depend on and hang ' +
+      'the game.');
+
+    renderer.requestRedraw();
+    assert.strictEqual(h.starts, 1,
+      `${id} is shown over a running animation, so the gate must stay open ` +
+      'and a redraw behind it must still reach the loop');
+  }
+});
+
+test('every close path resumes, including the ones that load a new board', () => {
+  // btn-puzzle-retry / btn-puzzle-next close the result modal and go straight
+  // into startPuzzle(), which replaces the board. startPuzzle() then calls
+  // hidePuzzleModals() over the top, closing all three. The second close must
+  // not undo the first, and neither may leave the game parked with a fresh
+  // puzzle on screen.
+  const h = makeHost();
+
+  modal.openModal('modal-puzzle-result');
+  modal.closeModal('modal-puzzle-result');          // the button handler
+  ['modal-puzzle-select', 'modal-puzzle-result', 'modal-puzzle-failed']
+    .forEach(modal.closeModal);                     // hidePuzzleModals()
+
+  assert.strictEqual(h.isPaused, false,
+    'a modal that pauses must resume on every exit path, including the ones ' +
+    'that go on to load a new puzzle');
+  assert.ok(h.starts >= 1, 'and the loop must be running for the new board');
+});
+
+test('closing a modal that is not open cannot unpause one that is', () => {
+  const h = makeHost();
+
+  modal.openModal('modal-puzzle-select');
+  // clearActivePuzzle() → hidePuzzleModals() closes all three defensively while
+  // only the selector is showing; the two absent ones must be no-ops.
+  modal.closeModal('modal-puzzle-result');
+  modal.closeModal('modal-puzzle-failed');
+
+  assert.strictEqual(h.isPaused, true,
+    'the pause is held by whichever pausing modal is still open, not by the ' +
+    'last close call to run');
+  assert.strictEqual(h.starts, 0, 'and the loop stays parked behind it');
+
+  modal.closeModal('modal-puzzle-select');
+  assert.strictEqual(h.isPaused, false, 'the last one out lifts the pause');
+});
+
+test('the selector handing over to the editor never unpauses in between', () => {
+  // btn-open-puzzle-editor: close the selector, open the editor. Both pause.
+  const h = makeHost();
+
+  modal.openModal('modal-puzzle-select');
+  modal.closeModal('modal-puzzle-select');
+  modal.openModal('modal-puzzle-editor');
+
+  assert.strictEqual(h.isPaused, true, 'the editor holds the pause the selector had');
+  modal.closeModal('modal-puzzle-editor');
+  assert.strictEqual(h.isPaused, false);
+});
+
+// ─── Repo gates ─────────────────────────────────────────────────
+
+test('the policy table covers every modal root in index.html', () => {
+  const html = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
+  const inHtml = [...html.matchAll(/id="(modal-[\w-]+)"/g)].map((m) => m[1]).sort();
+
+  assert.deepStrictEqual(inHtml, [...modal.MODAL_IDS].sort(),
+    'a modal root with no entry in MODAL_POLICY would fall through the seam ' +
+    'and silently skip the pause — which is precisely the bug #64 is about. ' +
+    'Add it to js/modal.js.');
+});
+
+/**
+ * The line #64 asks for: open/close is the seam's job and nobody else's.
+ *
+ * Scoped to `hidden` on *modal roots* — an id literal starting `modal-`, or a
+ * variable this file assigned from one. The dropdown, the rotate controls and
+ * the handedness pills toggle `hidden` too and are none of the seam's
+ * business, so they must stay allowed; a naive grep for "hidden" would flag
+ * them and be turned off within the week.
+ *
+ * A receiver the scan cannot resolve is also a failure. The pre-#64 code hid
+ * the puzzle modals through a computed id — `getElementById(id)` in a forEach —
+ * which no literal-based rule can see, and leaving that shape allowed would
+ * leave the gate trivially sidesteppable.
+ */
+test('nothing outside js/modal.js toggles hidden on a modal root', () => {
+  const files = fs.readdirSync(path.join(ROOT, 'js'))
+    .filter((f) => f.endsWith('.js') && f !== 'modal.js');
+
+  const violations = [];
+
+  for (const file of files) {
+    const src = fs.readFileSync(path.join(ROOT, 'js', file), 'utf8');
+
+    // Locals assigned from a modal root: `const failedModal = getElementById('modal-…')`
+    const rootVars = new Set(
+      [...src.matchAll(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*document\s*\.\s*getElementById\(\s*['"]modal-/g)]
+        .map((m) => m[1]),
+    );
+
+    for (const m of src.matchAll(/\.\s*classList\s*\.\s*(?:add|remove|toggle)\(\s*['"]hidden['"]/g)) {
+      const before = src.slice(0, m.index);
+      const line = before.split('\n').length;
+      const where = `js/${file}:${line}`;
+
+      const literal = before.match(/getElementById\(\s*(['"])([^'"]*)\1\s*\)\s*\??\s*$/);
+      if (literal) {
+        if (literal[2].startsWith('modal-')) {
+          violations.push(`${where} — hides modal root '${literal[2]}' directly`);
+        }
+        continue;
+      }
+
+      const ident = before.match(/([A-Za-z_$][\w$]*)\s*\??\s*$/);
+      if (ident) {
+        if (rootVars.has(ident[1])) {
+          violations.push(`${where} — hides modal root via '${ident[1]}'`);
+        }
+        continue;
+      }
+
+      violations.push(
+        `${where} — unresolvable receiver for a 'hidden' toggle; if this is a ` +
+        'modal it must go through js/modal.js, and if it is not, give it a ' +
+        'plain named variable so this gate can tell');
+    }
+  }
+
+  assert.deepStrictEqual(violations, [],
+    'modal open/close belongs to js/modal.js — that is the whole point of ' +
+    'hecknsic#64. A hand-rolled toggle skips the pause, the resume, or the ' +
+    'pending-action clear, and which one it skips is a coin flip:\n' +
+    violations.join('\n'));
+});

--- a/tests/modal-seam.test.js
+++ b/tests/modal-seam.test.js
@@ -214,11 +214,11 @@ test('the end-of-run modals stay non-pausing so the explosion can tick', () => {
     const h = makeHost();
     modal.openModal(id);
     assert.strictEqual(h.isPaused, false,
-      `${id} must NOT pause: handleGameOver()/handleOverAchiever() show it and ` +
-      'then await a 1.5 s tween that blows the board apart behind it, and ' +
-      'handleGameWin() is the tail of an animation its caller is still ' +
-      'awaiting. Pausing would park the loop those awaits depend on and hang ' +
-      'the game.');
+      `${id} must NOT pause: handleGameOver()/handleOverAchiever() (now in ` +
+      'js/game-state.js) show it and then await the 1.5 s explodeBoard() tween ' +
+      'that blows the board apart behind it, and handleGameWin() runs inside a ' +
+      'cascade loop that goes on awaiting after it. Pausing would park the ' +
+      'loop those awaits depend on and hang the game.');
 
     renderer.requestRedraw();
     assert.strictEqual(h.starts, 1,

--- a/tests/power-saver.test.js
+++ b/tests/power-saver.test.js
@@ -34,6 +34,7 @@ const power    = await import('../js/power.js');
 const frame    = await import('../js/frame.js');
 const renderer = await import('../js/renderer.js');
 const { tween } = await import('../js/tween.js');
+const input    = await import('../js/input.js');
 
 /** Every decorative effect the game can throw, in one call. */
 function spawnAllDecoration() {
@@ -86,6 +87,29 @@ test('power saver drops decoration and keeps the readouts', () => {
   launcher.push(true);   // a full transition, which fires the clear
   assert.strictEqual(renderer.hasActiveRendererAnimations(), true,
     'the clear must take the confetti and leave the readout');
+});
+
+test('a UI button gesture wakes the loop it was queued against', () => {
+  launcher.push(false);
+
+  let running = false;
+  let starts = 0;
+  frame.registerFrameLoop(
+    { start() { running = true; starts++; }, running: () => running },
+    () => true,
+  );
+
+  input.clearPendingAction();
+  running = false;
+  input.triggerAction('rotateCW');
+
+  assert.strictEqual(input.hasPendingAction(), true,
+    'precondition: the gesture is queued for the loop to consume');
+  assert.strictEqual(starts, 1,
+    'the rotate buttons queue an action without touching the canvas, so ' +
+    'triggerAction() is the only thing that can wake the loop for them — ' +
+    'without it the gesture sits in the queue until some unrelated event ' +
+    'restarts the loop, which then answers a stale rotation');
 });
 
 test('a parked loop is woken by a redraw request and by a new tween', () => {

--- a/tests/rotation-cancel.test.js
+++ b/tests/rotation-cancel.test.js
@@ -13,6 +13,17 @@
  * start paths) close the common door; these tests pin the backstop, which is
  * what makes a door someone forgets to close harmless.
  *
+ * The backstop changed shape in hecknsic#66 and these tests changed with it.
+ * It used to be a generation number the animator compared by hand after its
+ * last await; it is now the board's cancellation token (js/cancel.js), which
+ * the animator awaits *through*, so replacing the board throws Cancelled out
+ * of whichever tween is in flight. The thing being pinned is the same and the
+ * assertions below are unchanged: whatever the mechanism, a rotation must not
+ * commit to a board that replaced the one it started on. What the mid-flight
+ * swap does is now `token.cancel()` instead of `ctx.boardGeneration = 2` —
+ * that is what the state machine itself does on a restart, mode switch or
+ * puzzle load.
+ *
  * Tweens normally advance from the game loop's rAF callback. There is no loop
  * here, so the pump below calls updateTweens() directly; reducedMotion makes
  * every tween zero-duration, so one pump call retires one await.
@@ -40,6 +51,7 @@ globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame;
 const { animateClusterRotation, animateRingRotation, animateYRotation } =
   await import('../js/animations.js');
 const { updateTweens } = await import('../js/tween.js');
+const { createCancelToken, isCancelled } = await import('../js/cancel.js');
 
 /**
  * Hand-cranked tween clock. `step()` retires exactly one await of the
@@ -81,14 +93,12 @@ function makeCtx(grid) {
     grid,
     activeCols: grid.length,
     activeRows: grid[0].length,
-    boardGeneration: 1,
+    token: createCancelToken(1),
     selectedCluster: [
       { col: 2, row: 2 }, { col: 3, row: 2 }, { col: 2, row: 3 },
     ],
     flowerCenter: { col: 3, row: 3 },
     pearlCenter: { col: 3, row: 3 },
-    state: 'rotating',
-    setState() {},
   };
 }
 
@@ -108,15 +118,25 @@ async function rotateWithBoardReplacedMidFlight(animate) {
   // is parked on its next tween, with the rest of the rotation still ahead.
   await clock.step();
 
-  // What switchGameMode()/startPuzzle() do to the context at this moment.
+  // What switchGameMode()/startPuzzle()/resetGame() do at this moment: the
+  // outgoing board's token is cancelled and the grid is replaced.
   const newGrid = makeGrid(7, 7, 100);
   const before = snapshot(newGrid);
   ctx.grid = newGrid;
-  ctx.boardGeneration = 2;
+  ctx.token.cancel();
 
-  await clock.runOut(running);
+  // The animator unwinds with Cancelled rather than returning, which is the
+  // point of the token: a `return` only ends the function that wrote it, so
+  // every caller up the stack needed its own check and two of them were
+  // missing (hecknsic#62). Anything else thrown here is a real failure and is
+  // re-raised.
+  let cancelled = false;
+  await clock.runOut(running).catch((err) => {
+    if (!isCancelled(err)) throw err;
+    cancelled = true;
+  });
 
-  return { newGrid, before, oldGrid };
+  return { newGrid, before, oldGrid, cancelled };
 }
 
 for (const [name, animate] of [
@@ -125,12 +145,17 @@ for (const [name, animate] of [
   ['animateYRotation', animateYRotation],
 ]) {
   test(`${name} does not touch a board that replaced its own`, async () => {
-    const { newGrid, before } = await rotateWithBoardReplacedMidFlight(animate);
+    const { newGrid, before, cancelled } = await rotateWithBoardReplacedMidFlight(animate);
 
     assert.deepStrictEqual(
       snapshot(newGrid), before,
       `${name} committed its rotation to the board that replaced the one it ` +
       'started on — the player sees three cells of a fresh game scrambled');
+
+    assert.strictEqual(cancelled, true,
+      `${name} ran to completion on a cancelled board. It must unwind with ` +
+      'Cancelled, so that everything awaiting it stops too rather than each ' +
+      'caller having to remember a check of its own');
   });
 }
 

--- a/tests/rotation-cancel.test.js
+++ b/tests/rotation-cancel.test.js
@@ -1,0 +1,152 @@
+/**
+ * rotation-cancel.test.js — a rotation that outlives its board must be a no-op.
+ *
+ * A rotation step is three awaited tweens long (~300 ms), and a cascade chains
+ * several of them. Anything that replaces the board in that window — a mode
+ * switch, a puzzle load, a restart — leaves an animation running with a stale
+ * `ctx.grid` reference. Before hecknsic#62 the animators committed their
+ * rotation unconditionally when the tweens finished, so the three cells they
+ * had picked out of the *old* board were scrambled on the *new* one, and the
+ * trailing clearAllOverrides() wiped whatever the new board had just set.
+ *
+ * The entry-point guards (isProcessing() on the mode switch and the puzzle
+ * start paths) close the common door; these tests pin the backstop, which is
+ * what makes a door someone forgets to close harmless.
+ *
+ * Tweens normally advance from the game loop's rAF callback. There is no loop
+ * here, so the pump below calls updateTweens() directly; reducedMotion makes
+ * every tween zero-duration, so one pump call retires one await.
+ */
+import test from 'node:test';
+import assert from 'node:assert';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+installArcade({ powerSaver: false, reducedMotion: true });
+
+globalThis.window = {
+  devicePixelRatio: 1,
+  matchMedia: () => ({ matches: true }),
+  requestAnimationFrame: () => 0,
+};
+globalThis.document = {
+  documentElement: { style: { setProperty() {} } },
+  getElementById: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame;
+
+const { animateClusterRotation, animateRingRotation, animateYRotation } =
+  await import('../js/animations.js');
+const { updateTweens } = await import('../js/tween.js');
+
+/**
+ * Hand-cranked tween clock. `step()` retires exactly one await of the
+ * animation under test and then yields a macrotask so the animator can run on
+ * to its next tween; `runOut()` finishes whatever is left. Stepping is what
+ * makes the mid-flight moment deterministic — a timer racing the animation
+ * lands after it has already committed about as often as not.
+ */
+function makeClock() {
+  let now = 0;
+  const tick = () => updateTweens(now += 1000);
+  return {
+    async step() { tick(); await new Promise(r => setTimeout(r, 0)); },
+    runOut(promise) {
+      const id = setInterval(tick, 1);
+      return promise.finally(() => clearInterval(id));
+    },
+  };
+}
+
+/** A grid whose every cell carries a unique colorIndex, so any swap shows up. */
+function makeGrid(cols, rows, base) {
+  const grid = [];
+  for (let c = 0; c < cols; c++) {
+    grid[c] = [];
+    for (let r = 0; r < rows; r++) {
+      grid[c][r] = { colorIndex: base + c * rows + r, special: null };
+    }
+  }
+  return grid;
+}
+
+const snapshot = (grid) =>
+  grid.map(col => col.map(cell => (cell ? { ...cell } : null)));
+
+/** The slice of getAnimationContext() the rotation animators read. */
+function makeCtx(grid) {
+  return {
+    grid,
+    activeCols: grid.length,
+    activeRows: grid[0].length,
+    boardGeneration: 1,
+    selectedCluster: [
+      { col: 2, row: 2 }, { col: 3, row: 2 }, { col: 2, row: 3 },
+    ],
+    flowerCenter: { col: 3, row: 3 },
+    pearlCenter: { col: 3, row: 3 },
+    state: 'rotating',
+    setState() {},
+  };
+}
+
+/**
+ * Run one animator, swapping the board out from under it after the first
+ * await — exactly what switchGameMode()/startPuzzle() do to a live rotation.
+ * Returns the replacement board and the snapshot it had before the swap.
+ */
+async function rotateWithBoardReplacedMidFlight(animate) {
+  const oldGrid = makeGrid(7, 7, 0);
+  const ctx = makeCtx(oldGrid);
+  const clock = makeClock();
+
+  const running = animate(ctx, true, 0, 0);
+
+  // One await retired: the animator has read its cells off the old board and
+  // is parked on its next tween, with the rest of the rotation still ahead.
+  await clock.step();
+
+  // What switchGameMode()/startPuzzle() do to the context at this moment.
+  const newGrid = makeGrid(7, 7, 100);
+  const before = snapshot(newGrid);
+  ctx.grid = newGrid;
+  ctx.boardGeneration = 2;
+
+  await clock.runOut(running);
+
+  return { newGrid, before, oldGrid };
+}
+
+for (const [name, animate] of [
+  ['animateClusterRotation', animateClusterRotation],
+  ['animateRingRotation', animateRingRotation],
+  ['animateYRotation', animateYRotation],
+]) {
+  test(`${name} does not touch a board that replaced its own`, async () => {
+    const { newGrid, before } = await rotateWithBoardReplacedMidFlight(animate);
+
+    assert.deepStrictEqual(
+      snapshot(newGrid), before,
+      `${name} committed its rotation to the board that replaced the one it ` +
+      'started on — the player sees three cells of a fresh game scrambled');
+  });
+}
+
+test('the harness really does reach the mutation when the board survives', async () => {
+  // Without this control the tests above could pass because the animation
+  // never got as far as rotating anything.
+  const grid = makeGrid(7, 7, 0);
+  const ctx = makeCtx(grid);
+  const before = snapshot(grid);
+
+  const clock = makeClock();
+  const running = animateClusterRotation(ctx, true, 0, 0);
+  await clock.step();
+  await clock.runOut(running);
+
+  assert.notDeepStrictEqual(
+    snapshot(grid), before,
+    'a rotation on a board that was never replaced must still commit');
+});

--- a/tests/score-timing.test.js
+++ b/tests/score-timing.test.js
@@ -1,0 +1,162 @@
+/**
+ * score-timing.test.js — the score counter runs on the clock, not on frames.
+ *
+ * updateDisplayScore(dt) took a delta and ignored it, closing a fixed 10% of
+ * the remaining gap per *call*. That made the counter's speed a function of
+ * the display: half speed on a 30 Hz panel, double on a 120 Hz one, and every
+ * frame the loop dropped was time the counter simply did not count. The board
+ * animates off the tween clock (#63); the counter was the one readout still
+ * animating off the frame rate.
+ *
+ * These tests pin both halves of the fix: the 60 fps behaviour is unchanged to
+ * the bit (so the feel everyone has been playing with is preserved), and any
+ * other frame rate reaches the same place in the same wall-clock time.
+ *
+ * js/score.js is a pure module — constants in, numbers out, no Arcade and no
+ * DOM — so it needs no launcher stub.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  awardMatch, resetScore, restoreScore,
+  getScore, getDisplayScore, updateDisplayScore, isScoreAnimating,
+} from '../js/score.js';
+
+/** One frame at 60 fps — the rate the old per-frame constants were tuned at. */
+const FRAME_60 = 1000 / 60;
+
+/** Put the counter at a known distance behind a known score. */
+function startAt(displayScore, score) {
+  resetScore();
+  restoreScore({ score, displayScore });
+}
+
+/** The exact expression updateDisplayScore used before it took the clock. */
+function legacyStep(displayScore, score) {
+  return Math.min(score, displayScore + Math.max(1, (score - displayScore) * 0.1));
+}
+
+/** Run `ms` of counter time in steps of `dt`, and report where it landed. */
+function run(ms, dt) {
+  let elapsed = 0;
+  while (elapsed < ms - 1e-9) {
+    updateDisplayScore(Math.min(dt, ms - elapsed));
+    elapsed += dt;
+  }
+  return getDisplayScore();
+}
+
+test('a 60 fps frame does exactly what the per-frame version did', () => {
+  // Every regime the old expression had: the eased branch far from the target,
+  // the floor branch close to it, and the clamp on the final step.
+  for (const [display, score] of [[0, 10000], [0, 5], [9995, 10000], [0, 1]]) {
+    let legacy = display;
+    startAt(display, score);
+
+    for (let i = 0; i < 200; i++) {
+      legacy = legacyStep(legacy, score);
+      updateDisplayScore(FRAME_60);
+      assert.equal(getDisplayScore(), Math.round(legacy),
+        `frame ${i} diverged from the legacy curve for ${display}→${score}`);
+    }
+  }
+});
+
+test('the counter tracks wall-clock time, not frame count', () => {
+  // 500 ms of counting, delivered three ways. A frame-rate-dependent counter
+  // puts these 2x apart; a time-based one puts them within rounding.
+  startAt(0, 10000);
+  const at60 = run(500, FRAME_60);
+
+  startAt(0, 10000);
+  const at30 = run(500, FRAME_60 * 2);
+
+  startAt(0, 10000);
+  const at120 = run(500, FRAME_60 / 2);
+
+  // Tolerance is for the discretisation of a continuous curve into steps, not
+  // for a rate difference: 1% of the distance travelled.
+  const tolerance = at60 * 0.01;
+  assert.ok(Math.abs(at30 - at60) <= tolerance,
+    `30 fps landed at ${at30}, 60 fps at ${at60}`);
+  assert.ok(Math.abs(at120 - at60) <= tolerance,
+    `120 fps landed at ${at120}, 60 fps at ${at60}`);
+});
+
+test('one long step matches many short ones over the same interval', () => {
+  startAt(0, 10000);
+  const stepped = run(400, FRAME_60);
+
+  startAt(0, 10000);
+  updateDisplayScore(400);
+  const jumped = getDisplayScore();
+
+  assert.ok(Math.abs(jumped - stepped) <= stepped * 0.01,
+    `one 400 ms step landed at ${jumped}, twenty-four 60 fps steps at ${stepped}`);
+});
+
+test('the minimum-step floor scales with time as well', () => {
+  // Close to the target the floor takes over from the eased curve — with a gap
+  // of 5, easing offers 0.5 and the floor offers 1. That floor was "1 point per
+  // frame", the other half of the frame-rate dependency, and it is now 1 point
+  // per 16.667 ms. So three 60 fps frames and one frame three times as long
+  // must land in the same place.
+  startAt(0, 5);
+  updateDisplayScore(FRAME_60 * 3);
+  const oneLongFrame = getDisplayScore();
+
+  startAt(0, 5);
+  for (let i = 0; i < 3; i++) updateDisplayScore(FRAME_60);
+  const threeShortFrames = getDisplayScore();
+
+  assert.equal(threeShortFrames, 3, 'precondition: the floor branch is what is under test');
+  assert.equal(oneLongFrame, threeShortFrames);
+});
+
+test('a small gap closes in the same wall-clock time at 30 and 60 fps', () => {
+  const closeTime = (dt) => {
+    startAt(0, 5);
+    let ms = 0;
+    while (isScoreAnimating() && ms < 5000) { updateDisplayScore(dt); ms += dt; }
+    return ms;
+  };
+
+  const at60 = closeTime(FRAME_60);
+  const at30 = closeTime(FRAME_60 * 2);
+
+  assert.ok(at60 < 5000 && at30 < 5000, 'the counter must actually finish');
+  // Within one step of each other — all that is left is where the final,
+  // clamped step falls. Before the fix this was a clean factor of two.
+  assert.ok(Math.abs(at30 - at60) <= FRAME_60 * 2,
+    `30 fps took ${at30.toFixed(1)} ms, 60 fps took ${at60.toFixed(1)} ms`);
+});
+
+test('a frame that reports no elapsed time advances nothing', () => {
+  // main.js resets lastTime to 0 when it parks the loop, and the first frame
+  // back is the one that would otherwise hand us the whole idle interval.
+  // Nothing here may invent progress from a dt it cannot trust.
+  for (const dt of [0, -5, NaN, undefined, Infinity]) {
+    startAt(0, 10000);
+    updateDisplayScore(dt);
+    assert.equal(getDisplayScore(), 0, `dt=${dt} moved the counter`);
+  }
+});
+
+test('the counter never overshoots the score, however large the step', () => {
+  startAt(0, 12345);
+  updateDisplayScore(60_000);  // a minute in one go
+  assert.equal(getDisplayScore(), 12345);
+  assert.equal(isScoreAnimating(), false);
+});
+
+test('the counter still catches up to points awarded mid-flight', () => {
+  resetScore();
+  awardMatch(3);
+  assert.ok(getScore() > 0, 'precondition: a match scores');
+  assert.equal(isScoreAnimating(), true);
+
+  let ms = 0;
+  while (isScoreAnimating() && ms < 10_000) { updateDisplayScore(FRAME_60); ms += FRAME_60; }
+  assert.equal(isScoreAnimating(), false, 'counter never reached the score');
+  assert.equal(getDisplayScore(), getScore());
+});

--- a/tests/tween-pause.test.js
+++ b/tests/tween-pause.test.js
@@ -1,0 +1,110 @@
+/**
+ * tween-pause.test.js — a tween must survive the loop parking under it.
+ *
+ * The game loop stops far more often than it used to: it parks on a settled
+ * board (§6d), it parks behind an open modal, and the launcher cancels it on
+ * suspend. Tween progress used to be measured against the raw rAF timestamp,
+ * so every one of those gaps counted as elapsed animation — open help
+ * mid-cascade and the first frame back read progress 1.0 for everything still
+ * in flight. These tests pin the clock that fixes it.
+ *
+ * Arcade has to be installed before js/tween.js is evaluated: tween() reads
+ * Arcade.settings.reducedMotion(), and frame.js comes along with it.
+ */
+import test from 'node:test';
+import assert from 'node:assert';
+import { installArcade } from './helpers/fake-arcade.mjs';
+
+installArcade({ powerSaver: false, reducedMotion: false });
+
+const { tween, updateTweens, suspendTweenClock, hasActiveTweens, linear } =
+  await import('../js/tween.js');
+
+/**
+ * Retire anything a previous test left live and hand the next one a clock that
+ * has just been suspended — i.e. exactly the state a fresh park leaves behind.
+ * Frames are stepped rather than jumped because the clock caps what one frame
+ * may contribute.
+ */
+function drain() {
+  suspendTweenClock();
+  let t = 0;
+  while (hasActiveTweens() && t < 1e6) { t += 200; updateTweens(t); }
+  suspendTweenClock();
+}
+
+test('a tween parked mid-flight resumes from where it was, not from the end', () => {
+  drain();
+
+  let progress = -1;
+  tween(300, p => { progress = p; }, linear);
+
+  // Frame one: the tween takes its start from here.
+  updateTweens(1000);
+  assert.strictEqual(progress, 0, 'precondition: the tween is at 0% on its first frame');
+
+  // 100 ms in — a third of the way through a 300 ms linear tween.
+  updateTweens(1100);
+  assert.ok(Math.abs(progress - 1 / 3) < 1e-9,
+    `expected 0.333 a third of the way in, got ${progress}`);
+
+  // The player opens a modal. The loop parks, sits there for eight seconds,
+  // and the next frame arrives with a timestamp eight seconds later.
+  suspendTweenClock();
+  updateTweens(9100);
+
+  assert.ok(Math.abs(progress - 1 / 3) < 1e-9,
+    'an announced park must not advance the tween at all: expected the same ' +
+    `0.333 on the first frame back, got ${progress}`);
+  assert.strictEqual(hasActiveTweens(), true,
+    'the tween must still be live after the park, not resolved by the gap');
+
+  // ...and it carries on from there rather than sitting permanently offset.
+  updateTweens(9200);
+  assert.ok(Math.abs(progress - 2 / 3) < 1e-9,
+    `progress should continue smoothly after the resume, got ${progress}`);
+
+  updateTweens(9300);
+  assert.strictEqual(progress, 1, 'the tween still finishes on its own duration');
+  assert.strictEqual(hasActiveTweens(), false, 'and retires when it does');
+});
+
+test('an unannounced frame gap costs a blink, not the whole tween', () => {
+  drain();
+
+  // A backgrounded tab is throttled by the browser with none of our park hooks
+  // firing, so the clock also caps what any single frame may contribute.
+  let progress = -1;
+  tween(2000, p => { progress = p; }, linear);
+
+  updateTweens(1000);
+  updateTweens(11000);   // ten seconds, unannounced
+
+  assert.ok(progress > 0 && progress < 0.5,
+    `an unreported ten-second gap must not run a 2 s tween to the end; got ${progress}`);
+  assert.strictEqual(hasActiveTweens(), true, 'the tween is still in flight');
+});
+
+test('reduced motion still completes on the first frame', () => {
+  drain();
+
+  // Reduced motion collapses the duration to 0, and that has to stay a
+  // property of the duration rather than of any elapsed time — the clock
+  // change must not make a snap-to-end tween wait for a frame delta.
+  const settings = globalThis.Arcade.settings;
+  const wasReduced = settings.reducedMotion;
+  settings.reducedMotion = () => true;
+
+  const seen = [];
+  try {
+    tween(400, p => seen.push(p), linear);
+  } finally {
+    settings.reducedMotion = wasReduced;
+  }
+
+  updateTweens(5000);
+  assert.deepStrictEqual(seen, [1],
+    'under reduced motion the tween must fire once at full progress on its ' +
+    'first frame, with no elapsed time at all');
+  assert.strictEqual(hasActiveTweens(), false, 'and retire immediately');
+});


### PR DESCRIPTION
Implements the six work packages from the architecture review: #62, #63, #64, #65, #66, #67.

Three of the six are bug fixes that stand on their own; three are the structural work that makes the class of bug harder to write again. One commit per issue, in dependency order, so this can be reviewed (or split) at commit boundaries.

## Why

Every regression this project hit recently — the double-speed loop (#55), the modal-close freeze (#57), the rotate buttons that stopped working after the idle-loop change, the stale rotation in #62 — lived in the same band of code: the coordination logic in `main.js`. That file was 1,264 lines whose top level is a script, so it could not be imported in node and had **zero** test coverage, while the pure modules (board, specials, puzzles) were well covered. The bugs were not where the tests were.

## What landed

| Commit | Issue | |
|---|---|---|
| `8b099a0` | #62 | A rotation could commit to a board that had already been replaced. The generation guard ran one line too late, and the entry points that swap the board — mode switch, puzzle load — were unguarded, unlike the restart buttons. |
| `223b4b9` | #63 | Tween progress came from a raw rAF timestamp that keeps running while frames do not. Open a modal mid-cascade and every live animation teleported to its end state. Tweens now run off a clock that only admits time between rendered frames. |
| `8ed9696` | #64 | Modal open/close was hand-rolled at every call site under two incompatible conventions; the puzzle modals never paused at all. One seam now owns the hidden class, the pause flag, resume-on-close and ghost-click clearing, for all eleven modals. |
| `b364ad6` | #67 | 42 dead imports, 30 dead exports, two copy-pasted helpers consolidated, `window.debug` gated behind `?debug`, the score counter made frame-rate independent, per-frame HUD lookups memoized. |
| `3e8dca2` | #65 | The state machine extracted into `js/game-state.js` (no DOM, repo-gated). `main.js` 1,264 → 772 lines. |
| `9302424` | #66 | 25 hand-written `boardGeneration !== gen` comparisons replaced by a token whose check lives *inside* the await. Animation context loses every write handle. Endgame presentation leaves `animations.js`. |

## Notable

**Tests 88 → 154.** The new coverage is only possible because the extracted modules are node-importable — that was the point of #65, not a side effect.

**Two pre-existing bugs fixed in passing.** `btn-newgame-gamewin` never hid the win modal. `resetGame` open-coded its own `gameFrameLoop.start()` — a second path that started the loop around the gate the whole §6d idle-parking design depends on. A third, a floating-piece leak when the board was replaced mid-gravity, surfaced while converting `runCascade` to `finally`-based cleanup.

**Repo gates added**, so the fixed patterns cannot quietly regress: every modal root in `index.html` needs a policy entry; no hidden-class toggle on a modal root may live outside the seam (unresolvable receivers fail too, closing the computed-id loophole); `game-state.js` and `animations.js` may not reference `document`/`window`; no file may contain a hand-written generation comparison.

**No storage keys moved.** `getCombinedModeId()` returns the identical string; the vestigial `_classic` suffix is now commented as frozen schema rather than silently changed.

**`package.json` gained `"type": "module"`** — it is a dev-only file, excluded from the deploy artifact, so nothing ships.

## Review notes

Two places deliberately go beyond a pure move, both flagged rather than slipped in:

- `nextResolution()` (#65) names the cascade's priority ladder as a pure function so its ordering can be tested — with the animators statically imported there was no other injection point. Same detectors, same order, same short-circuiting, same chained-delay placement.
- `settleBoard()` (#66) moves gravity+refill into `game-state.js`. It still mutates, so the context is not purely read-only, but the bomb-queue *rule* now lives on the state-machine side instead of being four hand-copied expressions in `animations.js`.

The five end-of-run modals are non-pausing **by policy**, which reads wrong until you see why: `handleGameOver`/`handleOverAchiever` show the modal and *then* await a 1.5 s explosion, and the two puzzle end-of-run modals open from a `setTimeout(600)` that can land mid-detonation. Pausing any of them would park the loop those awaits depend on. This is asserted, with the reasoning in the policy table.

## Verification

`fleet / test` (154 node tests) and `fleet / smoke` both pass. The smoke job is the meaningful one here: it boots the **staged deploy artifact** in headless Chromium against the real SDK and asserts the app drew a real frame — 4096 distinct colours, channel σ 66.0, over 114009 sampled pixels. That covers what I most wanted covered on a change this size: the module graph resolves in a browser (no ESM cycle from the new `game-state.js`), the four new modules are present in the artifact and precached, and the canvas renders rather than staying blank.

What CI does **not** cover is interaction. Nothing exercises rotation, cascades, modal open/close, mode switching mid-animation, or the endgame explosion in a browser — those are covered by node tests only. Worth a few minutes of manual play before merge: arcade game, rotate, cascade, form a starflower, let a bomb explode, switch modes mid-cascade, open/close each modal, load a puzzle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
